### PR TITLE
Fix interpolation for facespaces

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/netcdf_writer.jl
+++ b/src/netcdf_writer.jl
@@ -207,7 +207,10 @@ function interpolate_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
                 parent(
                     space.grid.vertical_grid.center_local_geometry.coordinates,
                 ),
-            )
+            )[
+                :,
+                1,
+            ]
         end
 
         zcoords = [Geometry.ZPoint(p) for p in vpts]

--- a/src/netcdf_writer_coordinates.jl
+++ b/src/netcdf_writer_coordinates.jl
@@ -122,7 +122,8 @@ function target_coordinates(
     Union{Spaces.CenterFiniteDifferenceSpace, Spaces.FaceFiniteDifferenceSpace},
 }
     if disable_vertical_interpolation
-        return Array(parent(Fields.coordinate_field(space).z))[:, 1]
+        cspace = Spaces.space(space, Grids.CellCenter())
+        return Array(parent(Fields.coordinate_field(cspace).z))[:, 1]
     end
 
     # Exponentially spaced with base e


### PR DESCRIPTION
I forgot why I used `center_local_geometry.coordinates`: we always want the coordinates of the centers even when we are given a FaceSpace. Therefore, `Fields.coordinate_field(space).z` is not equivalent, and leads to [errors](https://buildkite.com/clima/climaatmos-ci/builds/18363#018ef72c-7a9e-4265-aec3-f5c7de4119f5).

I agree that this is really ugly. At the end, what we need is a linear array of `ZPoints` with the reference coordinates of the centers. What is a better way?
