### PR TITLE
Move interpolated_z to CPU only for root

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.1.5"
+version = "0.1.6"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
```julia
    interpolated_physical_z = if ClimaComms.iamroot(ctx)
        maybe_move_to_cpu(interpolate(remapper, coords_z))
    else
        nothing
    end
```
does not work because `interpolate` has to be called by all the MPI processes (because interpolation is a distributed operation).

Fixes #27 

All green in ClimaAtmos CI: https://buildkite.com/clima/climaatmos-ci/builds/18796