### PR TITLE
Add option to sync NetCDF files

### DIFF
--- a/docs/src/writers.md
+++ b/docs/src/writers.md
@@ -41,6 +41,20 @@ dimension is any dataset.
 
 Do not forget to close your writers to avoid file corruption!
 
+To help reducing data loss, `NetCDFWriter` can force __syncing__, i.e. flushing
+the values to disk. Usually, NetCDF buffers writes to disk (because they are
+expensive), meaning values are not immediately written but are saved to disk in
+batch. This can result in data loss, and it is often useful to force NetCDF to
+write to disk (this is especially the case when working with GPUs). To do so,
+you can pass the `sync_schedule` function to the constructor of `NetCDFWriter`.
+When not `nothing`, `sync_schedule` is a callable that takes one argument (the
+`integrator`) and returns a bool. When the bool is true, the files that were
+modified since the last `sync` will be `sync`ed. For example, to force sync
+every 1000 steps, you can pass the
+`ClimaDiagnostics.Schedules.DivisorSchedule(1000)` schedule. By default, on
+GPUs, we call `sync` at the end of every time step for those files that need to
+be synced.
+
 Variables are saved as datasets with attributes, where the attributes include
 `long_name`, `standard_name`, `units`...
 
@@ -48,6 +62,7 @@ Variables are saved as datasets with attributes, where the attributes include
 ClimaDiagnostics.Writers.NetCDFWriter
 ClimaDiagnostics.Writers.interpolate_field!
 ClimaDiagnostics.Writers.write_field!
+ClimaDiagnostics.Writers.sync
 Base.close
 ```
 

--- a/src/Writers.jl
+++ b/src/Writers.jl
@@ -7,15 +7,36 @@ Currently, it implements:
 - `HDF5Writer`, to save raw `ClimaCore` `Fields` to HDF5 files
 - `NetCDFWriter`, to save remapped `ClimaCore` `Fields` to NetCDF files
 
-Writers are expected to implement:
+Writers can implement:
 - `interpolate_field!`
 - `write_field!`
 - `Base.close`
+- `sync`
 """
 module Writers
 
 import ..AbstractWriter, ..ScheduledDiagnostic
 import ..ScheduledDiagnostics: output_short_name, output_long_name
+
+function write_field!(writer::AbstractWriter, field, diagnostic, u, p, t)
+    # Nothing to be done here :)
+    return nothing
+end
+
+function Base.close(writer::AbstractWriter)
+    # Nothing to be done here :)
+    return nothing
+end
+
+function interpolate_field!(writer::AbstractWriter, field, diagnostic, u, p, t)
+    # Nothing to be done here :)
+    return nothing
+end
+
+function sync(writer::AbstractWriter)
+    # Nothing to be done here :)
+    return nothing
+end
 
 include("dummy_writer.jl")
 include("dict_writer.jl")

--- a/src/dict_writer.jl
+++ b/src/dict_writer.jl
@@ -56,13 +56,3 @@ end
 function Base.getindex(writer::DictWriter, key)
     return Base.getindex(writer.dict, key)
 end
-
-function Base.close(writer::DictWriter)
-    # Nothing to be done here :)
-    return nothing
-end
-
-function interpolate_field!(writer::DictWriter, field, diagnostic, u, p, t)
-    # Nothing to be done here :)
-    return nothing
-end

--- a/src/dummy_writer.jl
+++ b/src/dummy_writer.jl
@@ -3,17 +3,4 @@ scheduled diagnostic. Mostly useful for testing and debugging ClimaDiagnostics.
 """
 struct DummyWriter <: AbstractWriter end
 
-function write_field!(writer::DummyWriter, field, diagnostic, u, p, t)
-    # Nothing to be done here :)
-    # return nothing
-end
-
-function Base.close(writer::DummyWriter)
-    # Nothing to be done here :)
-    return nothing
-end
-
-function interpolate_field!(writer::DummyWriter, field, diagnostic, u, p, t)
-    # Nothing to be done here :)
-    return nothing
-end
+# All the methods are the default methods for AbstractWriter

--- a/src/hdf5_writer.jl
+++ b/src/hdf5_writer.jl
@@ -17,7 +17,9 @@ end
 
 Close all the files open in `writer`. (Currently no-op.)
 """
-Base.close(writer::HDF5Writer) = nothing
+function Base.close(writer::HDF5Writer)
+    return nothing
+end
 
 """
     HDF5Writer(output_dir)
@@ -54,10 +56,5 @@ function write_field!(writer::HDF5Writer, field, diagnostic, u, p, t)
     end
 
     Base.close(hdfwriter)
-    return nothing
-end
-
-function interpolate_field!(writer::HDF5Writer, field, diagnostic, u, p, t)
-    # Nothing to be done here :)
     return nothing
 end


### PR DESCRIPTION
Sometimes, NetCDF files need syncing (force-writing to disk). This seems to be particularly the case for GPU runs.

This PR adds an option to provide the `NetCDFWriter` with a schedule to call `NCDatasets.sync` based on arbitrary conditions.

The default behavior depends on the context: on CPUs, we let `NetCDF` manage its buffered writes, on GPUs, we call `sync` at the every time steps for those datasets that need to be synced (ie, those that were written since the last sync).

In general, we keep track of what files have been recently touched (adding them to a list internal to the `writer`) and whenever `sync` is called, `NCDatasets.sync` is called on those files. This ensures that only files that needs to be synced are synced and that calling `sync` twice in a row results in a no-op for the second `sync`.

Closes #33 
