### PR TITLE
Remove ! from `write_field!`

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -45,6 +45,6 @@ ClimaDiagnostics.Writers.DictWriter
 ClimaDiagnostics.Writers.NetCDFWriter
 ClimaDiagnostics.Writers.HDF5Writer
 ClimaDiagnostics.Writers.interpolate_field!
-ClimaDiagnostics.Writers.write_field!
+ClimaDiagnostics.Writers.write_field
 Base.close
 ```

--- a/docs/src/writers.md
+++ b/docs/src/writers.md
@@ -11,7 +11,7 @@ Writers are needed to save the computed diagnostics.
 
 Users are welcome to implement their own writers. A writer has to be a subtype
 of `AbstractWriter`and has to implement the `interpolate_field!` and
-`write_field!` methods. `interpolate_field!` can return `nothing` is no
+`write_field` methods. `interpolate_field!` can return `nothing` is no
 interpolation is needed.
 
 ## `NetCDFWriter`
@@ -61,7 +61,7 @@ Variables are saved as datasets with attributes, where the attributes include
 ```@docs
 ClimaDiagnostics.Writers.NetCDFWriter
 ClimaDiagnostics.Writers.interpolate_field!
-ClimaDiagnostics.Writers.write_field!
+ClimaDiagnostics.Writers.write_field
 ClimaDiagnostics.Writers.sync
 Base.close
 ```
@@ -73,7 +73,7 @@ interactive work and debugging.
 
 ```@docs
 ClimaDiagnostics.Writers.DictWriter
-ClimaDiagnostics.Writers.write_field!
+ClimaDiagnostics.Writers.write_field
 ```
 
 ## `HDF5Writer`
@@ -90,5 +90,5 @@ is being output.
 
 ```@docs
 ClimaDiagnostics.Writers.HDF5Writer
-ClimaDiagnostics.Writers.write_field!
+ClimaDiagnostics.Writers.write_field
 ```

--- a/src/AbstractTypes.jl
+++ b/src/AbstractTypes.jl
@@ -5,10 +5,10 @@
 
 An object that knows how to save some output.
 
-`AbstractWriter`s have to provide one function, `write_field!`
+`AbstractWriter`s have to provide one function, `write_field`
 
 The function has to have signature
-`write_field!(writer::Writer, field, diagnostic, u, p, t)`
+`write_field(writer::Writer, field, diagnostic, u, p, t)`
 
 It is up to the `Writer` to implement this.
 """

--- a/src/ScheduledDiagnostics.jl
+++ b/src/ScheduledDiagnostics.jl
@@ -30,7 +30,7 @@ struct ScheduledDiagnostic{
     output_schedule_func::T1
 
     """Struct that controls out to save the computed diagnostic variable to disk.
-    `output_writer` has to implement a method `write_field!` that takes three arguments: the
+    `output_writer` has to implement a method `write_field` that takes three arguments: the
     value that has to be output, the `ScheduledDiagnostic`, and the integrator. Internally,
     the integrator contains extra information (such as the current timestep). It is
     responsibility of the `output_writer` to properly use the provided information for

--- a/src/Writers.jl
+++ b/src/Writers.jl
@@ -9,7 +9,7 @@ Currently, it implements:
 
 Writers can implement:
 - `interpolate_field!`
-- `write_field!`
+- `write_field`
 - `Base.close`
 - `sync`
 """
@@ -18,7 +18,7 @@ module Writers
 import ..AbstractWriter, ..ScheduledDiagnostic
 import ..ScheduledDiagnostics: output_short_name, output_long_name
 
-function write_field!(writer::AbstractWriter, field, diagnostic, u, p, t)
+function write_field(writer::AbstractWriter, field, diagnostic, u, p, t)
     # Nothing to be done here :)
     return nothing
 end

--- a/src/clima_diagnostics.jl
+++ b/src/clima_diagnostics.jl
@@ -2,7 +2,7 @@ import Accessors
 import SciMLBase
 
 import .Schedules: DivisorSchedule, EveryDtSchedule
-import .Writers: interpolate_field!, write_field!, sync, AbstractWriter
+import .Writers: interpolate_field!, write_field, sync, AbstractWriter
 
 # We define all the known identities in reduction_identities.jl
 include("reduction_identities.jl")
@@ -43,7 +43,7 @@ An object to instantiate and manage storage spaces for `ScheduledDiagnostics`.
 
 The `DiagnosticsHandler` calls `compute!(nothing, Y, p, t)` for each diagnostic. The result
 is used to allocate the areas of memory for storage and accumulation. For diagnostics
-without reduction, `write_field!(output_writer, result, diagnostic, Y, p, t)` is called too.
+without reduction, `write_field(output_writer, result, diagnostic, Y, p, t)` is called too.
 
 Note: initializing a `DiagnosticsHandler` can be expensive.
 
@@ -92,7 +92,7 @@ function DiagnosticsHandler(scheduled_diagnostics, Y, p, t; dt = nothing)
         # If it is not a reduction, call the output writer as well
         if !isa_time_reduction
             interpolate_field!(diag.output_writer, storage[diag], diag, Y, p, t)
-            write_field!(diag.output_writer, storage[diag], diag, Y, p, t)
+            write_field(diag.output_writer, storage[diag], diag, Y, p, t)
         else
             # Add to the accumulator
 
@@ -202,7 +202,7 @@ function orchestrate_diagnostics(
         active_output[diag_index] || continue
         diag = scheduled_diagnostics[diag_index]
 
-        write_field!(
+        write_field(
             diag.output_writer,
             diagnostic_handler.storage[diag],
             diag,

--- a/src/dict_writer.jl
+++ b/src/dict_writer.jl
@@ -30,7 +30,7 @@ function DictWriter()
 end
 
 """
-    write_field!(writer::DictWriter, field, diagnostic, u, p, t)
+    write_field(writer::DictWriter, field, diagnostic, u, p, t)
 
 Add an entry to the `writer` at time `t` for the current `diagnostic` with value
 `field`.
@@ -44,7 +44,7 @@ that value.
 `DictWriter` implements a basic read-only dictionary interface to access the
 times and values.
 """
-function write_field!(writer::DictWriter, field, diagnostic, u, p, t)
+function write_field(writer::DictWriter, field, diagnostic, u, p, t)
     key_name =
         diagnostic isa ScheduledDiagnostic ? output_short_name(diagnostic) :
         diagnostic

--- a/src/hdf5_writer.jl
+++ b/src/hdf5_writer.jl
@@ -31,7 +31,7 @@ The name of the file is determined by the `output_short_name` of the output
 
 `Field`s can be read back using the `InputOutput` module in `ClimaCore`.
 """
-function write_field!(writer::HDF5Writer, field, diagnostic, u, p, t)
+function write_field(writer::HDF5Writer, field, diagnostic, u, p, t)
     var = diagnostic.variable
     time = t
 

--- a/src/netcdf_writer.jl
+++ b/src/netcdf_writer.jl
@@ -272,7 +272,7 @@ function interpolate_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
 end
 
 """
-    write_field!(writer::NetCDFWriter, field::Fields.Field, diagnostic, u, p, t)
+    write_field(writer::NetCDFWriter, field::Fields.Field, diagnostic, u, p, t)
 
 Save the resampled `field` produced by `diagnostic` as directed by the `writer`.
 
@@ -291,7 +291,7 @@ Attributes are appended to the dataset:
 - `comments`
 - `start_date`
 """
-function write_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
+function write_field(writer::NetCDFWriter, field, diagnostic, u, p, t)
     # Only the root process has to write
     ClimaComms.iamroot(ClimaComms.context(field)) || return nothing
 

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -21,11 +21,11 @@ output_dir = mktempdir(".")
     writer = Writers.DictWriter()
 
     # Test with some strings and floats instead of actual Fields and ScheduledDiagnostics
-    Writers.write_field!(writer, 10.0, "mytest", nothing, nothing, 0.0)
+    Writers.write_field(writer, 10.0, "mytest", nothing, nothing, 0.0)
     @test writer.dict["mytest"][0.0] == 10.0
-    Writers.write_field!(writer, 20.0, "mytest", nothing, nothing, 2.0)
+    Writers.write_field(writer, 20.0, "mytest", nothing, nothing, 2.0)
     @test writer.dict["mytest"][2.0] == 20.0
-    Writers.write_field!(writer, 50.0, "mytest2", nothing, nothing, 8.0)
+    Writers.write_field(writer, 50.0, "mytest2", nothing, nothing, 8.0)
     @test writer.dict["mytest2"][8.0] == 50.0
 end
 
@@ -76,7 +76,7 @@ end
         output_writer = writer,
     )
     Writers.interpolate_field!(writer, field, diagnostic, u, p, t)
-    Writers.write_field!(writer, field, diagnostic, u, p, t)
+    Writers.write_field(writer, field, diagnostic, u, p, t)
 
     @test writer.unsynced_datasets ==
           Set((writer.open_files[joinpath(output_dir, "my_short_name.nc")],))
@@ -114,7 +114,7 @@ end
         p,
         t,
     )
-    Writers.write_field!(
+    Writers.write_field(
         writer_no_vert_interpolation,
         field,
         diagnostic_novert,
@@ -123,7 +123,7 @@ end
         t,
     )
     # Write a second time
-    Writers.write_field!(
+    Writers.write_field(
         writer_no_vert_interpolation,
         field,
         diagnostic_novert,
@@ -149,18 +149,12 @@ end
     Profile.clear()
 
     # Profile write
-    Profile.@profile Writers.write_field!(writer, field, diagnostic, u, p, t)
+    Profile.@profile Writers.write_field(writer, field, diagnostic, u, p, t)
     ProfileCanvas.html_file("flame_write_netcdf.html", Profile.fetch())
 
     # Benchmark write
-    timing_write_field = @benchmark Writers.write_field!(
-        $writer,
-        $field,
-        $diagnostic,
-        $u,
-        $p,
-        $t,
-    )
+    timing_write_field =
+        @benchmark Writers.write_field($writer, $field, $diagnostic, $u, $p, $t)
 
     # Compare against pure NCDatasets
     function add_nc(nc, outarray, p)


### PR DESCRIPTION
`write_field!` used to modify the NetCDF writer, but this is no longer the case, so the use of ! is no longer needed
