### PR TITLE
Introduce z_sampling_method, remove disable_vertical_interpolation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,9 @@
+# NEWS
+
+v0.2.0
+-------
+
+- ![][badge-💥breaking]The `NetCDFWriter` now outputs points on the vertical levels by default.
+- ![][badge-💥breaking] `disable_vertical_interpolation` is removed in favor of `z_sampling_method`.
+
+[badge-💥breaking]: https://img.shields.io/badge/💥BREAKING-red.svg

--- a/docs/src/writers.md
+++ b/docs/src/writers.md
@@ -7,7 +7,8 @@ Writers are needed to save the computed diagnostics.
 - `DictWriter`, to save `Field`s to dictionaries in memory;
 - `HDF5Writer`, to save `Field`s to HDF5 files.
 
-(There is an additional `DummyWriter` that does nothing. It is mostly used internally for testing and debugging.)
+(There is an additional `DummyWriter` that does nothing. It is mostly used
+internally for testing and debugging.)
 
 Users are welcome to implement their own writers. A writer has to be a subtype
 of `AbstractWriter`and has to implement the `interpolate_field!` and
@@ -30,6 +31,15 @@ and the output directory where the files should be saved. By default, the
 `NetCDFWriter` appends to existing files and create new ones if they do not
 exist. The `NetCDFWriter` does not overwrite existing data and will error out if
 existing data is inconsistent with the new one.
+
+`NetCDFWriter`s take as one of the inputs the desired number of points along
+each of the dimensions. For the horizontal dimensions, points are sampled
+linearly. For the vertical dimension, the behavior can be customized by passing
+the `z_sampling_method` variable. When `z_sampling_method =
+ClimaDiagnostics.Writers.LevelMethod()`, points evaluated on the grid levels
+(and the provided number of points ignored), when `z_sampling_method =
+ClimaDiagnostics.Writers.FakePressureLevelMethod()`, points are sampled
+uniformly in simplified hydrostatic atmospheric model.
 
 The output in the `NetCDFWriter` roughly follows the CF conventions.
 
@@ -65,6 +75,15 @@ ClimaDiagnostics.Writers.write_field!
 ClimaDiagnostics.Writers.sync
 Base.close
 ```
+
+Sampling methods for the vertical direction:
+```@docs
+ClimaDiagnostics.Writers.AbstractZSamplingMethod
+ClimaDiagnostics.Writers.LevelsMethod
+ClimaDiagnostics.Writers.FakePressureLevelsMethod
+Base.close
+```
+
 
 ## `DictWriter`
 

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -113,7 +113,7 @@ end
             NCDatasets.NCDataset(joinpath(output_dir, "YO_1it_inst.nc")) do nc
                 @test nc["YO"].attrib["short_name"] == "YO"
                 @test nc["YO"].attrib["long_name"] == "YO YO, Instantaneous"
-                @test size(nc["YO"]) == (11, 10, 5, 3)
+                @test size(nc["YO"]) == (11, 10, 5, 10)
             end
 
             NCDatasets.NCDataset(
@@ -122,13 +122,13 @@ end
                 @test nc["YO"].attrib["short_name"] == "YO"
                 @test nc["YO"].attrib["long_name"] ==
                       "YO YO, average within every 2 iterations"
-                @test size(nc["YO"]) == (5, 10, 5, 3)
+                @test size(nc["YO"]) == (5, 10, 5, 10)
             end
 
             NCDatasets.NCDataset(joinpath(output_dir, "YO_3s_inst.nc")) do nc
                 @test nc["YO"].attrib["short_name"] == "YO"
                 @test nc["YO"].attrib["long_name"] == "YO YO, Instantaneous"
-                @test size(nc["YO"]) == (4, 10, 5, 3)
+                @test size(nc["YO"]) == (4, 10, 5, 10)
             end
         end
     end

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -41,13 +41,14 @@ end
         output_dir;
         num_points = (NUM, NUM, NUM),
         sync_schedule = ClimaDiagnostics.Schedules.DivisorSchedule(2),
+        z_sampling_method = ClimaDiagnostics.Writers.FakePressureLevelsMethod(),
     )
 
     writer_no_vert_interpolation = Writers.NetCDFWriter(
         space,
         output_dir;
         num_points = (NUM, NUM, NUM),
-        disable_vertical_interpolation = true,
+        z_sampling_method = ClimaDiagnostics.Writers.LevelsMethod(),
     )
 
     # Check Base.show


### PR DESCRIPTION
The NetCDF writer was originally designed for ClimaAtmos. As such, it uses some fake pressure levels for vertical sampling as default. This is generally not applicable/useful. This commit generalized the method to sample points on the vertical direction introducing a new type `AbstractZSamplingMethod`.

`AbstractZSamplingMethod` has to concrete subtypes:
- `LevelsMethod` (equivalent to `disable_vertical_interpolation`)
- `FakePressureLevelsMethod` (equivalent to previously default behavior)

This opens up the possibility to also define `LinearMethod`, for linear sampling, and `LogMethod`, for log sampling.

The default was changed to `LevelsMethod` and `disable_vertical_interpolation` was deprecated.

Closes #6 