### PR TITLE
Add actual condition to run orchestrate_diagnostics

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -79,8 +79,17 @@ because it creates a new integrator obtained by copying all the fields of the
 old one and adding the diagnostics (with
 [`Accessors`](https://github.com/JuliaObjects/Accessors.jl)).
 
+The `DiagnosticsHandler` also contains three `BitVectors`: `active_compute`,
+`active_output`, `active_sync`. These `BitVectors` have the same length as the
+number of scheduled diagnostics and signal whether something should done at a
+given step. The `BitVectors` are defined and preallocated trying to reduce the
+inference allocations that result from operations like `filter` on lists of
+`ScheduledDiagnostics`. They are updated by a callback that is run before
+`orchestrate_diagnostics` and they can be used to determine if
+`orchestrate_diagnostics` should be run at all.
+
 ## Orchestrate diagnostics
 
 One of the design goals for `orchestrate_diagnostics` is to keep all the
 broadcasted expression in the same function scope. This opens a path to optimize
-the number of GPU kernel launches. 
+the number of GPU kernel launches.

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -63,7 +63,7 @@ include("TestTools.jl")
         dt,
     )
 
-    diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
+    diag_cbs = ClimaDiagnostics.DiagnosticsCallbacks(diagnostic_handler)
 
     prob = SciMLBase.ODEProblem(
         ClimaTimeSteppers.ClimaODEFunction(T_exp! = exp_tendency!),
@@ -71,9 +71,20 @@ include("TestTools.jl")
         (t0, tf),
         p,
     )
+
+    @test ClimaDiagnostics.check_callback_condition(
+        prob,
+        diagnostic_handler,
+    ) === false
+
     algo = ClimaTimeSteppers.ExplicitAlgorithm(ClimaTimeSteppers.RK4())
 
-    SciMLBase.solve(prob, algo, dt = dt, callback = diag_cb)
+    SciMLBase.solve(prob, algo, dt = dt, callback = diag_cbs)
+
+    @test ClimaDiagnostics.check_callback_condition(
+        prob,
+        diagnostic_handler,
+    ) === true
 
     @test length(keys(dict_writer.dict[short_name])) ==
           convert(Int, 1 + (tf - t0) / dt)
@@ -100,7 +111,7 @@ include("TestTools.jl")
         dt,
     )
 
-    diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
+    diag_cbs = ClimaDiagnostics.DiagnosticsCallbacks(diagnostic_handler)
 
     prob = SciMLBase.ODEProblem(
         ClimaTimeSteppers.ClimaODEFunction(T_exp! = exp_tendency!),
@@ -110,7 +121,7 @@ include("TestTools.jl")
     )
     algo = ClimaTimeSteppers.ExplicitAlgorithm(ClimaTimeSteppers.RK4())
 
-    SciMLBase.solve(prob, algo, dt = dt, callback = diag_cb)
+    SciMLBase.solve(prob, algo, dt = dt, callback = diag_cbs)
 
     @test length(keys(dict_writer.dict[short_name])) ==
           convert(Int, (tf - t0) / 5dt)


### PR DESCRIPTION
This closes #37, but I am not sure if it is worth the additional complexity (even if it is not much more complex, it's mostly the fact that now there two callbacks have to be added).

This PR pulls out the condition to run the diagnostic callback from the diagnostic callback, so that `callback.condition` is reflective on whether the diagnostic callback will be run or not. However, the diagnostic callback might be running for compute, output, or sync, and I expect compute to be on almost all iterations, so that `condition` will not be particularly informative. To make it more useful, we could further split the callbacks to compute, output, cleanup, and sync to provide more granular information on what is schedule to happen.
