### PR TITLE
Detect and ignore duplicated diagnostics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,7 +4,6 @@ agents:
   modules: climacommon/2024_05_27
 
 env:
-  JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"
   JULIA_DEPOT_PATH: "${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/depot/default"
   SLURM_KILL_BAD_EXIT: 1
 

--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -24,12 +24,12 @@ jobs:
       matrix:
         package:
           - 'ClimaAtmos.jl'
+          - 'ClimaLand.jl'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1
         with:
           version: '1.10'
-          arch: 'x86'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: actions/checkout@v4

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # NEWS
 
+v0.2.3
+-------
+
+- Detect and ignore duplicated diagnostics.
+
+
 v0.2.2
 -------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,12 +5,10 @@ v0.2.3
 
 - Detect and ignore duplicated diagnostics.
 
-
 v0.2.2
 -------
 
 - Fix support for caches that are not NamedTuples in `NetCDFWriter`.
-
 
 v0.2.1
 -------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.2.2"
+version = "0.2.3"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/clima_diagnostics.jl
+++ b/src/clima_diagnostics.jl
@@ -61,7 +61,12 @@ function DiagnosticsHandler(scheduled_diagnostics, Y, p, t; dt = nothing)
     accumulators = Dict()
     counters = Dict()
 
-    for diag in scheduled_diagnostics
+    unique_scheduled_diagnostics = Tuple(unique(scheduled_diagnostics))
+    if length(unique_scheduled_diagnostics) != length(scheduled_diagnostics)
+        @warn "Given list of diagnostics contains duplicates, removing them"
+    end
+
+    for diag in unique_scheduled_diagnostics
         if isnothing(dt)
             @warn "dt was not passed to DiagnosticsHandler. No checks will be performed on the frequency of the diagnostics"
         else
@@ -106,7 +111,7 @@ function DiagnosticsHandler(scheduled_diagnostics, Y, p, t; dt = nothing)
     end
 
     return DiagnosticsHandler(
-        Tuple(scheduled_diagnostics),
+        unique_scheduled_diagnostics,
         storage,
         accumulators,
         counters,

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -147,4 +147,40 @@ include("TestTools.jl")
         dt,
     )
 
+    # Test duplicated diagnostics
+    diagnostic1 = ClimaDiagnostics.ScheduledDiagnostic(
+        variable = simple_var,
+        output_writer = dict_writer,
+    )
+    diagnostic2 = ClimaDiagnostics.ScheduledDiagnostic(
+        variable = simple_var,
+        output_writer = dict_writer,
+    )
+    diagnostic3 = ClimaDiagnostics.ScheduledDiagnostic(
+        variable = simple_var,
+        output_writer = dict_writer,
+        reduction_time_func = +,
+    )
+
+    @test_logs (
+        :warn,
+        "Given list of diagnostics contains duplicates, removing them",
+    ) handler_dup = ClimaDiagnostics.DiagnosticsHandler(
+        [diagnostic1, diagnostic2, diagnostic3],
+        Y,
+        p,
+        t0;
+        dt,
+    )
+
+    handler_dup = ClimaDiagnostics.DiagnosticsHandler(
+        [diagnostic1, diagnostic2, diagnostic3],
+        Y,
+        p,
+        t0;
+        dt,
+    )
+
+    @test length(handler_dup.scheduled_diagnostics) == 2
+
 end


### PR DESCRIPTION
ClimaDiagnostics assumes that diagnostics are unique (they are used as
keys), but never checks them. Now we check and remove duplicates.

Closes #60 