### PR TITLE
Add support for calendar periods

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # NEWS
 
+v0.2.4
+-------
+
+- Add `EveryCalendarDtSchedule` for schedules with calendar periods.
+
 v0.2.3
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.2.3"
+version = "0.2.4"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,13 @@ format = Documenter.HTML(
     mathengine = mathengine,
 )
 
+DocMeta.setdocmeta!(
+    ClimaDiagnostics,
+    :DocTestSetup,
+    :(using Dates);
+    recursive = true,
+)
+
 makedocs(
     sitename = "ClimaDiagnostics.jl",
     authors = "Gabriele Bozzola",

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -15,7 +15,7 @@ ClimaDiagnostics.Schedules.long_name
 ClimaDiagnostics.Schedules.DivisorSchedule
 ClimaDiagnostics.Schedules.EveryStepSchedule
 ClimaDiagnostics.Schedules.EveryDtSchedule
-
+ClimaDiagnostics.Schedules.EveryCalendarDtSchedule
 ```
 
 ## `DiagnosticVariables`

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -20,6 +20,7 @@ the Developer guide page.
 - Define diagnostics as function of the integrator state and the cache;
 - Accumulate diagnostics over period of times with associative binary temporal
   reductions (eg, averages);
+- Work with calendar dates (eg, monthly averages);
 - Allow users to define arbitrary new diagnostics;
 - Trigger diagnostics on arbitrary conditions;
 - Save output to HDF5 or NetCDF files, or a dictionary in memory;

--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -185,6 +185,10 @@ end
 ```
 Names are not too important, but they should be meaningful to you.
 
+`ClimaDiagnostics` comes with some predefined schedules for common operations,
+such out every N timesteps, or every calendar period. Refer to the docstrings in
+[`Schedules`](@ref) for more information on what is already implemented.
+
 ##### Temporal reductions
 
 It is often useful to compute aggregate data (e.g., monthly averages). In

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,5 @@
+import Dates
+
 """
     seconds_to_str_short(time_seconds::Real)
 
@@ -6,9 +8,8 @@ Convert a time in seconds to a string representing the time in "short" units.
 Examples:
 ========
 
-```julia
-julia> seconds_to_str_short(0)
-"0s"
+```jldoctest
+julia> import ClimaDiagnostics: seconds_to_str_short
 
 julia> seconds_to_str_short(0.1)
 "0.1s"
@@ -50,9 +51,8 @@ Convert a time in seconds to a string representing the time in "longer" units.
 Examples:
 ========
 
-```julia
-julia> seconds_to_str_long(0)
-"0 Seconds"
+```jldoctest
+julia> import ClimaDiagnostics: seconds_to_str_long
 
 julia> seconds_to_str_long(60)
 "1 Minutes"
@@ -82,4 +82,126 @@ function seconds_to_str_long(time_seconds::Real)
     seconds > 0 && (name *= "$(seconds) Seconds ")
 
     return rstrip(name, ' ')
+end
+
+"""
+    time_to_date(time::AbstractFloat, reference_date::Dates.DateTime, t_start = 0)
+
+Convert a `time` in seconds from `reference_date` to a `Dates.DateTime`.
+
+Examples:
+========
+
+```jldoctest
+julia> import Dates: DateTime
+
+julia> import ClimaDiagnostics: time_to_date
+
+julia> reference_date = DateTime(2024, 1, 1, 0, 0, 0);
+
+julia> time_to_date(0.0, reference_date)
+2024-01-01T00:00:00
+
+julia> time_to_date(1.0, reference_date, t_start = 5.0)
+2024-01-01T00:00:06
+
+julia> time_to_date(0.5, reference_date)
+2024-01-01T00:00:00.500
+
+julia> time_to_date(-1.0, reference_date)
+2023-12-31T23:59:59
+
+julia> time_to_date(1.25, reference_date)
+2024-01-01T00:00:01.250
+```
+"""
+function time_to_date(
+    time::AbstractFloat,
+    reference_date::Dates.DateTime;
+    t_start = zero(time),
+)
+    # We go through nanoseconds to allow fractions of a second (otherwise, Second(0.8) would fail)
+    time_ms = Dates.Nanosecond(1_000_000_000 * (t_start + time))
+    return reference_date + time_ms
+end
+
+"""
+    period_to_str_short(time_seconds::Real)
+
+Convert a time in seconds to a string representing the time in "short" units.
+
+Examples:
+========
+
+# Examples
+```jldoctest
+julia> import ClimaDiagnostics: period_to_str_short
+
+julia> period_to_str_short(Dates.Year(1))
+"1y"
+
+julia> period_to_str_short(Dates.Month(3))
+"3M"
+
+julia> period_to_str_short(Dates.Day(5))
+"5d"
+
+julia> period_to_str_short(Dates.Hour(2))
+"2h"
+
+julia> period_to_str_short(Dates.Minute(10))
+"10m"
+
+julia> period_to_str_short(Dates.Second(30))
+"30s"
+```
+"""
+function period_to_str_short(period::Dates.Period)
+    return replace(
+        string(period),
+        r"year(s)?" => "y",
+        r"month(s)?" => "M",
+        r"day(s)?" => "d",
+        r"hour(s)?" => "h",
+        r"minute(s)?" => "m",
+        r"second(s)?" => "s",
+        " " => "",
+        "," => "_",  # For Dates.CompundPeriod
+    )
+end
+
+"""
+    period_to_str_long(time_seconds::Real)
+
+Convert a time in seconds to a string representing the time in "long" units.
+
+Examples:
+========
+
+# Examples
+```jldoctest
+julia> import ClimaDiagnostics: period_to_str_long
+
+julia> period_to_str_long(Dates.Year(1))
+"1 Year"
+
+julia> period_to_str_long(Dates.Month(2))
+"2 Months"
+
+julia> period_to_str_long(Dates.Day(5))
+"5 Days"
+
+julia> period_to_str_long(Dates.Hour(12))
+"12 Hours"
+
+julia> period_to_str_long(Dates.Minute(30))
+"30 Minutes"
+
+julia> period_to_str_long(Dates.Second(45))
+"45 Seconds"
+```
+"""
+function period_to_str_long(period::Dates.Period)
+    period_str = replace(string(period), "," => "")
+    return join(uppercasefirst.(split(period_str)), " ")
 end

--- a/test/doctest.jl
+++ b/test/doctest.jl
@@ -1,6 +1,15 @@
+using Test
 using Documenter
 import ClimaDiagnostics
 
 @testset "Test docstrings" begin
+
+    DocMeta.setdocmeta!(
+        ClimaDiagnostics,
+        :DocTestSetup,
+        :(using Dates);
+        recursive = true,
+    )
+
     doctest(ClimaDiagnostics; manual = false)
 end


### PR DESCRIPTION
This PR adds a new schedule, `EveryCalendarDtSchedule` that is aware of `Dates.Period` objects, allowing for true monthly diagnostics.

Closes #66 