### PR TITLE
Improve support for latlon boxes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # NEWS
 
+v0.2.5
+-------
+
+## Features
+
+### Add support for box spaces with LatLong points in `NetCDFWriter`.
+
+The `NetCDFWriter` can now work with regional boxes with `LatLong` points. Due
+to incompatibility in `ClimaCore`, only `LatLong` points are supported (and not
+`LongLat` points). This means that the box has to be created with latitude on
+the x axis and longitude on the y axis.
+
 v0.2.4
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.2.4"
+version = "0.2.5"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/test/TestTools.jl
+++ b/test/TestTools.jl
@@ -62,6 +62,66 @@ function SphericalShellSpace(;
     )
 end
 
+function BoxSpace(;
+    FT = Float64,
+    xlim = (-FT(1), FT(1)),
+    ylim = (-FT(1), FT(1)),
+    height = 10.0,
+    lonlat = false,
+    nelements = (10, 10),
+    zelem = 10,
+    npolynomial = 4,
+    context = ClimaComms.context(),
+)
+    vertdomain = ClimaCore.Domains.IntervalDomain(
+        ClimaCore.Geometry.ZPoint(FT(0)),
+        ClimaCore.Geometry.ZPoint(FT(height));
+        boundary_names = (:bottom, :top),
+    )
+    vertmesh = ClimaCore.Meshes.IntervalMesh(vertdomain; nelems = zelem)
+    if pkgversion(ClimaCore) >= v"0.14.10"
+        vert_center_space = ClimaCore.Spaces.CenterFiniteDifferenceSpace(
+            ClimaComms.device(context),
+            vertmesh,
+        )
+    else
+        vert_center_space =
+            ClimaCore.Spaces.CenterFiniteDifferenceSpace(vertmesh)
+    end
+
+    # NOTE: here we assume LatPoint is first
+    XPoint = lonlat ? ClimaCore.Geometry.LatPoint : ClimaCore.Geometry.XPoint
+    YPoint = lonlat ? ClimaCore.Geometry.LongPoint : ClimaCore.Geometry.YPoint
+    periodic = !lonlat
+    boundary_names = (:first, :second)
+
+    domain_x = ClimaCore.Domains.IntervalDomain(
+        XPoint(xlim[1]),
+        XPoint(xlim[2]);
+        periodic,
+        boundary_names,
+    )
+
+    domain_y = ClimaCore.Domains.IntervalDomain(
+        YPoint(ylim[1]),
+        YPoint(ylim[2]);
+        periodic,
+        boundary_names,
+    )
+
+    horzdomain = ClimaCore.Domains.RectangleDomain(domain_x, domain_y)
+    horzmesh =
+        ClimaCore.Meshes.RectilinearMesh(horzdomain, nelements[1], nelements[2])
+    horztopology = ClimaCore.Topologies.Topology2D(context, horzmesh)
+    quad = ClimaCore.Spaces.Quadratures.GLL{npolynomial + 1}()
+    horzspace = ClimaCore.Spaces.SpectralElementSpace2D(horztopology, quad)
+
+    return ClimaCore.Spaces.ExtrudedFiniteDifferenceSpace(
+        horzspace,
+        vert_center_space,
+    )
+end
+
 """
     create_problem()
 

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -133,6 +133,79 @@ end
         t,
     )
 
+    # Check boxes
+    xyboxspace = BoxSpace()
+    xyboxfield = Fields.coordinate_field(xyboxspace).z
+
+    xyboxwriter = Writers.NetCDFWriter(
+        xyboxspace,
+        output_dir;
+        num_points = (NUM, NUM, NUM),
+    )
+    xyboxdiagnostic = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute!,
+            short_name = "ABC",
+        ),
+        output_short_name = "my_short_name_xybox",
+        output_long_name = "My Long Name",
+        output_writer = xyboxwriter,
+    )
+    xyboxu = (; xyboxfield)
+    Writers.interpolate_field!(
+        xyboxwriter,
+        xyboxfield,
+        xyboxdiagnostic,
+        xyboxu,
+        p,
+        t,
+    )
+    Writers.write_field!(xyboxwriter, xyboxfield, xyboxdiagnostic, xyboxu, p, t)
+
+    longlatboxspace = BoxSpace(; lonlat = true)
+    longlatboxfield = Fields.coordinate_field(longlatboxspace).z
+
+    longlatboxwriter = Writers.NetCDFWriter(
+        longlatboxspace,
+        output_dir;
+        num_points = (NUM, NUM, NUM),
+    )
+    longlatboxdiagnostic = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute!,
+            short_name = "ABC",
+        ),
+        output_short_name = "my_short_name_longlatbox",
+        output_long_name = "My Long Name",
+        output_writer = longlatboxwriter,
+    )
+    longlatboxu = (; longlatboxfield)
+    Writers.interpolate_field!(
+        longlatboxwriter,
+        longlatboxfield,
+        longlatboxdiagnostic,
+        longlatboxu,
+        p,
+        t,
+    )
+    Writers.write_field!(
+        longlatboxwriter,
+        longlatboxfield,
+        longlatboxdiagnostic,
+        longlatboxu,
+        p,
+        t,
+    )
+    # Write a second time, to check consistency
+    Writers.write_field!(
+        longlatboxwriter,
+        longlatboxfield,
+        longlatboxdiagnostic,
+        longlatboxu,
+        p,
+        t,
+    )
+
     ###############
     # Performance #
     ###############

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -34,12 +34,12 @@ end
     field = Fields.coordinate_field(space).z
 
     # Number of interpolation points
-    NUM = 100
+    NUM = 50
 
     writer = Writers.NetCDFWriter(
         space,
         output_dir;
-        num_points = (NUM, NUM, NUM),
+        num_points = (NUM, 2NUM, 3NUM),
         sync_schedule = ClimaDiagnostics.Schedules.DivisorSchedule(2),
         z_sampling_method = ClimaDiagnostics.Writers.FakePressureLevelsMethod(),
     )
@@ -47,7 +47,7 @@ end
     writer_no_vert_interpolation = Writers.NetCDFWriter(
         space,
         output_dir;
-        num_points = (NUM, NUM, NUM),
+        num_points = (NUM, 2NUM, 3NUM),
         z_sampling_method = ClimaDiagnostics.Writers.LevelsMethod(),
     )
 
@@ -91,7 +91,7 @@ end
         @test nc["ABC"].attrib["units"] == ""
         @test nc["ABC"].attrib["start_date"] ==
               string(Dates.DateTime(1453, 5, 29))
-        @test size(nc["ABC"]) == (1, NUM, NUM, NUM)
+        @test size(nc["ABC"]) == (1, NUM, 2NUM, 3NUM)
         @test nc["time"][1] == 10.0
         @test nc["date"][1] ==
               string(Dates.DateTime(1453, 5, 29) + Dates.Second(10.0))
@@ -140,7 +140,7 @@ end
     xyboxwriter = Writers.NetCDFWriter(
         xyboxspace,
         output_dir;
-        num_points = (NUM, NUM, NUM),
+        num_points = (NUM, 2NUM, 3NUM),
     )
     xyboxdiagnostic = ClimaDiagnostics.ScheduledDiagnostic(;
         variable = ClimaDiagnostics.DiagnosticVariable(;
@@ -168,7 +168,7 @@ end
     longlatboxwriter = Writers.NetCDFWriter(
         longlatboxspace,
         output_dir;
-        num_points = (NUM, NUM, NUM),
+        num_points = (NUM, 2NUM, 3NUM),
     )
     longlatboxdiagnostic = ClimaDiagnostics.ScheduledDiagnostic(;
         variable = ClimaDiagnostics.DiagnosticVariable(;
@@ -253,8 +253,8 @@ end
     NCDatasets.defVar(nc, "time", Float64, ("time",))
     NCDatasets.defVar(nc, "date", String, ("time",))
     NCDatasets.defDim(nc, "x", NUM)
-    NCDatasets.defDim(nc, "y", NUM)
-    NCDatasets.defDim(nc, "z", NUM)
+    NCDatasets.defDim(nc, "y", 2NUM)
+    NCDatasets.defDim(nc, "z", 3NUM)
     v = NCDatasets.defVar(
         nc,
         "my_short_name",


### PR DESCRIPTION
This commit makes identifying coordinates for resampling more coordinate-agnostic.

This commit introduces a workaround for
https://github.com/CliMA/ClimaCore.jl/issues/1936

More fundamentally, https://github.com/CliMA/ClimaCore.jl/issues/1936 is
probably a reflection of the fact that boxes with longlat points are not
supported extremely well.

Closes #70 
Closes #71 
