### PR TITLE
Ensure that DictWriter is constructed with Dicts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,10 @@ to incompatibility in `ClimaCore`, only `LatLong` points are supported (and not
 `LongLat` points). This means that the box has to be created with latitude on
 the x axis and longitude on the y axis.
 
+## Bug fixes
+
+- Ensure that `DictWriter` can only be constructed with dictionary-like objects.
+
 v0.2.4
 -------
 

--- a/src/dict_writer.jl
+++ b/src/dict_writer.jl
@@ -4,7 +4,7 @@ dictionary).
 This is particularly useful for testing and debugging. This is not type stable
 (the underlying dictionary does not know in advance what types might be used).
 """
-struct DictWriter{T} <: AbstractWriter
+struct DictWriter{T <: AbstractDict} <: AbstractWriter
     """Underlying dictionary. Keys are the short names of the diagnostics, values are
     dictionaries that map the time to the value."""
     dict::T


### PR DESCRIPTION
One might accidentally use the default constructor for DictWriter. DictWriter could have been creted with a type that does not make sense. This commit ensures that DictWriter can only be constructed with objects that behave like dictionaries.
