### PR TITLE
Remove t_start, rename reference_date->start_date

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # NEWS
 
+main
+-------
+
+### Deprecations
+
+`reference_date` was renamed to `start_date` and `t_start` was dropped from the
+constructors for the schedules. These changes are due to the fact that these
+arguments should not be needed.
+
 v0.2.5
 -------
 

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -264,19 +264,19 @@ For example, you could provide
 ```julia
 using ClimaDiagnostics.Callbacks: EveryStepSchedule, EveryDtSchedule
 
-function monthly_average(short_name; output_writer, t_start)
-    period = 30 * 24 * 60 * 60 * one(t_start)
+function monthly_average(FT, short_name; output_writer)
+    period = 30 * 24 * 60 * 60 * one(FT)
     return ScheduledDiagnostic(
             variable = get_diagnostic_variable(short_name),
             compute_schedule_func = EveryStepSchedule(),
-            output_schedule_func = EveryDtSchedule(period; t_start),
+            output_schedule_func = EveryDtSchedule(period),
             reduction_time_func = (+),
             output_writer = output_writer,
             pre_output_hook! = average_pre_output_hook!,
         )
 end
 ```
-Allowing users to just call `monthly_average("hus", writer, t_start)`.
+Allowing users to just call `monthly_average(Float32, "hus", writer)`.
 
 > Note: `ClimaDiagnostics` will probably provided these schedules natively at
 > some point in the future.
@@ -366,14 +366,14 @@ function parse_yaml(parsed_args, target_space)
             period_seconds = FT(time_to_seconds(yaml_diag["period"]))
 
             if isnothing(reduction_time_func)
-                compute_every = CAD.EveryDtSchedule(period_seconds; t_start)
+                compute_every = CAD.EveryDtSchedule(period_seconds)
             else
                 compute_every = CAD.EveryStepSchedule()
             end
 
             ScheduledDiagnostic(
                 variable = get_diagnostic_variable(short_name),
-                output_schedule_func = CAD.EveryDtSchedule(period_seconds; t_start),
+                output_schedule_func = CAD.EveryDtSchedule(period_seconds),
                 compute_schedule_func = compute_every,
                 reduction_time_func = reduction_time_func,
                 pre_output_hook! = pre_output_hook!,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -85,9 +85,9 @@ function seconds_to_str_long(time_seconds::Real)
 end
 
 """
-    time_to_date(time::AbstractFloat, reference_date::Dates.DateTime, t_start = 0)
+    time_to_date(time::AbstractFloat, start_date::Dates.DateTime)
 
-Convert a `time` in seconds from `reference_date` to a `Dates.DateTime`.
+Convert a `time` in seconds from `start_date` to a `Dates.DateTime`.
 
 Examples:
 ========
@@ -97,32 +97,29 @@ julia> import Dates: DateTime
 
 julia> import ClimaDiagnostics: time_to_date
 
-julia> reference_date = DateTime(2024, 1, 1, 0, 0, 0);
+julia> start_date = DateTime(2024, 1, 1, 0, 0, 0);
 
-julia> time_to_date(0.0, reference_date)
+julia> time_to_date(0.0, start_date)
 2024-01-01T00:00:00
 
-julia> time_to_date(1.0, reference_date, t_start = 5.0)
-2024-01-01T00:00:06
-
-julia> time_to_date(0.5, reference_date)
+julia> time_to_date(0.5, start_date)
 2024-01-01T00:00:00.500
 
-julia> time_to_date(-1.0, reference_date)
+julia> time_to_date(-1.0, start_date)
 2023-12-31T23:59:59
 
-julia> time_to_date(1.25, reference_date)
+julia> time_to_date(1.25, start_date)
 2024-01-01T00:00:01.250
 ```
 """
-function time_to_date(
-    time::AbstractFloat,
-    reference_date::Dates.DateTime;
-    t_start = zero(time),
-)
-    # We go through nanoseconds to allow fractions of a second (otherwise, Second(0.8) would fail)
-    time_ms = Dates.Nanosecond(1_000_000_000 * (t_start + time))
-    return reference_date + time_ms
+function time_to_date(time::AbstractFloat, start_date::Dates.DateTime)
+    # We go through milliseconds to allow fractions of a second (otherwise, Second(0.8)
+    # would fail). Milliseconds is the level of resolution that one gets when taking the
+    # difference between two DateTimes. In addition to this, we add a round to account for
+    # floating point errors. If the floating point error is small enough, round will correct
+    # it.
+    time_ms = Dates.Millisecond(round(1_000 * time))
+    return start_date + time_ms
 end
 
 """

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -71,7 +71,7 @@ function setup_integrator(output_dir; context, more_compute_diagnostics = 0)
         output_writer = nc_writer,
         output_schedule_func = ClimaDiagnostics.Schedules.EveryDtSchedule(
             3.0,
-            t_start = t0,
+            t_last = t0,
         ),
     )
     inst_diagnostic_h5 = ClimaDiagnostics.ScheduledDiagnostic(


### PR DESCRIPTION
`t_start` and `reference_date` were added following an incorrect assumption (that restarts would restart at t = 0). The names were taken from ClimaLand, where these variables were used slightly differently (`reference_date` might have been the first date available in a file, and `t_start` allowed to run at at different point in that file).

Passing Atmos job: https://buildkite.com/clima/climaatmos-ci/builds/20465
