### PR TITLE
Fix reference of schedule

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@ main
 Release `0.2.6` improves compatibility with CF conventions by adding
 - standard and long name for the `time`, `longitude`, and `latitude` dimensions
 
+## Bug fixes
+
+- The default constructor for `ScheduleDiagnostic`s no longer uses reference of
+  `Schedule`s but create a new copy.
+
 ### Deprecations
 
 `reference_date` was renamed to `start_date` and `t_start` was dropped from the

--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -189,8 +189,15 @@ end
 Names are not too important, but they should be meaningful to you.
 
 `ClimaDiagnostics` comes with some predefined schedules for common operations,
-such out every N timesteps, or every calendar period. Refer to the [`Schedules`](@ref schedules_header)
-section below for more information on what is already implemented.
+such out every N timesteps, or every calendar period. Refer to the
+[`Schedules`](@ref schedules_header) section below for more information on what
+is already implemented.
+
+!!! note
+
+    `Schedule`s store some information about the last time they were called, so
+    different `Schedule`s have to be used and created for different purposes.
+    You can use the `deepcopy` function to quickly create a new `Schedule`.
 
 ##### Temporal reductions
 

--- a/src/ScheduledDiagnostics.jl
+++ b/src/ScheduledDiagnostics.jl
@@ -158,7 +158,8 @@ function ScheduledDiagnostic(;
     reduction_time_func = nothing,
     compute_schedule_func = EveryStepSchedule(),
     output_schedule_func = isnothing(reduction_time_func) ?
-                           compute_schedule_func : EveryStepSchedule(),
+                           deepcopy(compute_schedule_func) :
+                           EveryStepSchedule(),
     pre_output_hook! = (accum, count) -> nothing,
     output_short_name = descriptive_short_name(
         variable,


### PR DESCRIPTION
Schedules have to be unique objects because they store information about they were last called. The constructor of `ScheduledDiagnostics` was using a reference instead of a copy, which led to incorrect scheduling.
