### PR TITLE
Save ScheduleDiagnostics as Vectors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,10 @@
 
 main
 -------
+## Bug fixes
 
+- `scheduled_diagnostics` are now internally saved as vectors instead of tuples.
+  This has significant compile-time/inference benefits.
 
 v0.2.6
 -------

--- a/src/clima_diagnostics.jl
+++ b/src/clima_diagnostics.jl
@@ -13,12 +13,7 @@ include("reduction_identities.jl")
 A struct that contains the scheduled diagnostics, ancillary data and areas of memory needed
 to store and accumulate results.
 """
-struct DiagnosticsHandler{
-    SD <: Tuple,
-    STORAGE <: Dict,
-    ACC <: Dict,
-    COUNT <: Dict,
-}
+struct DiagnosticsHandler{SD, STORAGE <: Dict, ACC <: Dict, COUNT <: Dict}
     """An iterable with the `ScheduledDiagnostic`s that are scheduled."""
     scheduled_diagnostics::SD
 
@@ -61,7 +56,7 @@ function DiagnosticsHandler(scheduled_diagnostics, Y, p, t; dt = nothing)
     accumulators = Dict()
     counters = Dict()
 
-    unique_scheduled_diagnostics = Tuple(unique(scheduled_diagnostics))
+    unique_scheduled_diagnostics = unique(scheduled_diagnostics)
     if length(unique_scheduled_diagnostics) != length(scheduled_diagnostics)
         @warn "Given list of diagnostics contains duplicates, removing them"
     end


### PR DESCRIPTION
`ScheduleDiagnostic`s with `NetCDFWriter`s have a complex type structure that can lead to significant compile time. We originally saved `ScheduleDiagnostic`s internally as tuples to improve inferrability, but this does not seem to scale well with lots of diagnostics.

In the future, we might want to consider looking at the type signature and move the reference to the writer outside of `ScheduleDiagnostic`s and into the `DiagnosticHandler`.

Hopefully, closes #83 