### PR TITLE
Add missing feature in IntegratorWithDiagnostics

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -46,3 +46,4 @@ steps:
       CLIMACOMMS_CONTEXT: "MPI"
     agents:
       slurm_ntasks: 2
+    timeout_in_minutes: 20

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,16 @@
 main
 -------
 
+v0.2.8
+-------
+
+## Bug fixes
+
+- `IntegratorWithDiagnostics` advertised a feature that was not implemented:
+  `IntegratorWithDiagnostics` claimed that passing `state_name` and `cache_name`
+  would allow users to customize the name of the state and cache inside the
+  integrator. Now, this is implemented.
+
 v0.2.7
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/clima_diagnostics.jl
+++ b/src/clima_diagnostics.jl
@@ -283,7 +283,9 @@ end
 
 """
     IntegratorWithDiagnostics(integrator,
-                              scheduled_diagnostics)
+                              scheduled_diagnostics;
+                              state_name = :u,
+                              cache_name = :p)
 
 Return a new `integrator` with diagnostics defined by `scheduled_diagnostics`.
 
@@ -301,11 +303,16 @@ after everything else is initialized and computed.
 `integrator.p`. This behavior can be customized by passing the `state_name` and `cache_name`
 keyword arguments.
 """
-function IntegratorWithDiagnostics(integrator, scheduled_diagnostics)
+function IntegratorWithDiagnostics(
+    integrator,
+    scheduled_diagnostics;
+    state_name = :u,
+    cache_name = :p,
+)
     diagnostics_handler = DiagnosticsHandler(
         scheduled_diagnostics,
-        integrator.u,
-        integrator.p,
+        getproperty(integrator, state_name),
+        getproperty(integrator, cache_name),
         integrator.t;
         integrator.dt,
     )


### PR DESCRIPTION
IntegratorWithDiagnostics claimed to support customizing the
`state_name` and the `cache_name`, but this was never implemented. This
commit adds this feature (needed by ClimaLand).
