### PR TITLE
Acquire ownership of data returned by compute!

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,15 @@
 main
 -------
 
+## Bug fixes
+
+Prior to this version, `ClimaDiagnostics` would directly store use the output
+returned by `compute!` functions the first time they are called. This leads to
+problems when the output is a reference to an existing object since multiple
+diagnostics would modify the same object. Now, `ClimaDiagnostics` makes a copy
+of the return object so that it is no longer necessary to do so in the
+`compute!` function.
+
 v0.2.8
 -------
 

--- a/docs/src/developer_guide.md
+++ b/docs/src/developer_guide.md
@@ -238,7 +238,7 @@ add_diagnostic_variable!(
     units = "kg m^-3",
     compute! = (out, state, cache, time) -> begin
         if isnothing(out)
-            return copy(state.c.ρ)
+            return state.c.ρ
         else
             out .= state.c.ρ
         end

--- a/docs/src/user_guide.md
+++ b/docs/src/user_guide.md
@@ -39,7 +39,7 @@ import ClimaDiagnostics: DiagnosticVariable
 
 function compute_ta!(out, state, cache, time)
     if isnothing(out)
-        return copy(state.ta)
+        return state.ta
     else
         out .= state.ta
     end

--- a/src/clima_diagnostics.jl
+++ b/src/clima_diagnostics.jl
@@ -107,8 +107,9 @@ function DiagnosticsHandler(scheduled_diagnostics, Y, p, t; dt = nothing)
         isa_time_reduction = !isnothing(diag.reduction_time_func)
 
         # The first time we call compute! we use its return value. All the subsequent times
-        # (in the callbacks), we will write the result in place
-        push!(storage, variable.compute!(nothing, Y, p, t))
+        # (in the callbacks), we will write the result in place. We call copy to acquire ownership
+        # of the data in case compute! returned a reference.
+        push!(storage, copy(variable.compute!(nothing, Y, p, t)))
         push!(counters, 1)
 
         # If it is not a reduction, call the output writer as well

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -42,7 +42,7 @@ function setup_integrator(output_dir; context, more_compute_diagnostics = 0)
 
     function compute_my_var!(out, u, p, t)
         if isnothing(out)
-            return copy(u.my_var)
+            return u.my_var
         else
             out .= u.my_var
             return nothing

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -61,7 +61,7 @@ end
 
     function compute!(out, u, p, t)
         if isnothing(out)
-            return copy(u.field)
+            return u.field
         else
             out .= u.field
         end


### PR DESCRIPTION
Prior to this version, `ClimaDiagnostics` would directly store use the output returned by `compute!` functions the first time they are called. This leads to problems when the output is a reference to an existing object since multiple diagnostics would modify the same object. Now, `ClimaDiagnostics` makes a copy of the return object so that it is no longer necessary to do so in the `compute!` function.

Fixes problem found by @szy21 with radiation