### PR TITLE
Add start date to NetCDF attributes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,14 @@
 v0.2.9
 -------
 
+## Features
+
+### Add a `start_date` attribute to NetCDFWriter PR [#94](https://github.com/CliMA/ClimaDiagnostics.jl/pull/94).
+
+Prior to this version, users had to go to the simution to find the start date.
+It can now be saved as an attribute, making it easily accessible.
+To do so, users need to pass the kwarg `start_date` when calling `NetCDFWriter`.
+
 ## Bug fixes
 
 ### Acquiring ownership with `compute!` PR [#88](https://github.com/CliMA/ClimaDiagnostics.jl/pull/88).

--- a/docs/src/writers.md
+++ b/docs/src/writers.md
@@ -18,7 +18,7 @@ interpolation is needed.
 ## `NetCDFWriter`
 
 The `NetCDFWriter` resamples the input `Field` to a rectangular grid and saves
-the output to a NetCDF file. 
+the output to a NetCDF file.
 
 The `NetCDFWriter` relies on the `Remappers` module in `ClimaCore` to
 interpolate onto the rectangular grid. Horizontally, this interpolation is a
@@ -31,6 +31,9 @@ and the output directory where the files should be saved. By default, the
 `NetCDFWriter` appends to existing files and create new ones if they do not
 exist. The `NetCDFWriter` does not overwrite existing data and will error out if
 existing data is inconsistent with the new one.
+
+Optionally (recommended), you can pass an optional argument `start_date`, which
+will be saved as an attribute of your NetCDF file, easily accessible.
 
 `NetCDFWriter`s take as one of the inputs the desired number of points along
 each of the dimensions. For the horizontal dimensions, points are sampled

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -7,6 +7,8 @@ import NCDatasets
 
 import ClimaDiagnostics
 
+import Dates
+
 import ClimaComms
 @static if pkgversion(ClimaComms) >= v"0.6"
     ClimaComms.@import_required_backends
@@ -38,6 +40,7 @@ function setup_integrator(output_dir; context, more_compute_diagnostics = 0)
         space,
         output_dir;
         num_points = (10, 5, 3),
+        start_date = Dates.DateTime(2015, 2, 2),
     )
 
     function compute_my_var!(out, u, p, t)
@@ -126,6 +129,8 @@ end
                 @test nc["YO"].attrib["short_name"] == "YO"
                 @test nc["YO"].attrib["long_name"] == "YO YO, Instantaneous"
                 @test size(nc["YO"]) == (11, 10, 5, 10)
+                @test nc["YO"].attrib["start_date"] ==
+                string(Dates.DateTime(2015, 2, 2))
             end
 
             NCDatasets.NCDataset(


### PR DESCRIPTION
Add a `start_date` attribute to NetCDFWriter

Prior to this version, users had to go to the simution to find the start date.
It is now saved as an attribute, making it easily accessible.

