### PR TITLE
Tr/point space support

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,12 @@ This release adds support for working with `ITime`s. In particular,
 provided to make an `EveryCalendarDtSchedule` using `ITime`s. Lastly, there are
 small changes to the writers to support `ITime`s.
 
+v0.2.12
+-------
+## Bug fixes
+
+- `NetCDFWriter` now correctly writes purely vertical spaces.
+
 v0.2.11
 -------
 ## Bug fixes

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ v0.2.12
 -------
 ## Bug fixes
 
-- `NetCDFWriter` now correctly writes purely vertical spaces.
+- `NetCDFWriter` now correctly writes purely vertical and point spaces.
 
 v0.2.11
 -------

--- a/src/hdf5_writer.jl
+++ b/src/hdf5_writer.jl
@@ -1,5 +1,5 @@
 import ClimaComms
-import ClimaCore.InputOutput
+import ClimaCore: InputOutput, Spaces
 
 import ClimaUtilities.TimeManager: ITime
 
@@ -38,6 +38,11 @@ The name of the file is determined by the `output_short_name` of the output
 `Field`s can be read back using the `InputOutput` module in `ClimaCore`.
 """
 function write_field!(writer::HDF5Writer, field, diagnostic, u, p, t)
+    axes(field) isa Spaces.PointSpace &&
+        pkgversion(InputOutput) < v"0.14.27" &&
+        error(
+            "HDF5Writer only supports Fields with PointSpace for ClimaCore >= 0.14.27",
+        )
     var = diagnostic.variable
     time = t
 

--- a/src/netcdf_writer.jl
+++ b/src/netcdf_writer.jl
@@ -18,8 +18,14 @@ include("netcdf_writer_coordinates.jl")
 A struct to remap `ClimaCore` `Fields` to rectangular grids and save the output to NetCDF
 files.
 """
-struct NetCDFWriter{T, TS, DI, SYNC, ZSM <: AbstractZSamplingMethod, DATE} <:
-       AbstractWriter
+struct NetCDFWriter{
+    T,
+    TS,
+    DI,
+    SYNC,
+    ZSM <: Union{AbstractZSamplingMethod, Nothing},
+    DATE,
+} <: AbstractWriter
     """The base folder where to save the files."""
     output_dir::String
 
@@ -262,6 +268,42 @@ function NetCDFWriter(
     )
 end
 
+function NetCDFWriter(
+    space::Spaces.Spaces.PointSpace,
+    output_dir;
+    compression_level = 9,
+    sync_schedule = ClimaComms.device(space) isa ClimaComms.CUDADevice ?
+                    EveryStepSchedule() : nothing,
+    start_date = nothing,
+    kwargs...,
+)
+    comms_ctx = ClimaComms.context(space)
+    preallocated_arrays =
+        ClimaComms.iamroot(comms_ctx) ?
+        Dict{ScheduledDiagnostic, ClimaComms.array_type(space)}() :
+        Dict{ScheduledDiagnostic, Nothing}()
+    unsynced_datasets = Set{NCDatasets.NCDataset}()
+    return NetCDFWriter{
+        Nothing,
+        Nothing,
+        typeof(preallocated_arrays),
+        typeof(sync_schedule),
+        Nothing,
+        typeof(start_date),
+    }(
+        output_dir,
+        Dict{String, Remapper}(),
+        nothing,
+        compression_level,
+        nothing,
+        Dict{String, NCDatasets.NCDataset}(),
+        nothing,
+        preallocated_arrays,
+        sync_schedule,
+        unsynced_datasets,
+        start_date,
+    )
+end
 """
     interpolate_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
 
@@ -278,7 +320,7 @@ function interpolate_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
     if has_horizontal_space
         horizontal_space = Spaces.horizontal_space(space)
 
-        # We have to deal with to cases: when we have an horizontal slice (e.g., the
+        # We have to deal with two cases: when we have an horizontal slice (e.g., the
         # surface), and when we have a full space. We distinguish these cases by checking if
         # the given space has the horizontal_space attribute. If not, it is going to be a
         # SpectralElementSpace2D and we don't have to deal with the z coordinates.
@@ -391,6 +433,11 @@ function write_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
         interpolated_field = permutedims(interpolated_field, perm)
     end
 
+    if space isa Spaces.PointSpace
+        # If the space is a point space, we have to remove the singleton dimension
+        interpolated_field = interpolated_field[]
+    end
+
     FT = Spaces.undertype(space)
 
     output_path =
@@ -438,7 +485,8 @@ function write_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
         # We already have something in the file
         v = nc["$(var.short_name)"]
         temporal_size, spatial_size... = size(v)
-        spatial_size == size(interpolated_field) ||
+        interpolated_size = size(interpolated_field)
+        spatial_size == interpolated_size ||
             error("incompatible dimensions for $(var.short_name)")
     else
         v = NCDatasets.defVar(

--- a/src/netcdf_writer_coordinates.jl
+++ b/src/netcdf_writer_coordinates.jl
@@ -208,6 +208,19 @@ function add_space_coordinates_maybe!(
     return [name]
 end
 
+# PointSpace
+function add_space_coordinates_maybe!(
+    nc::NCDatasets.NCDataset,
+    space::Spaces.PointSpace,
+    num_points_z;
+    z_sampling_method,
+    names = (),
+    interpolated_physical_z = nothing, # Not needed here, but needed for consistency of
+    # interface and dispatch
+)
+    return []
+end
+
 add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
     space::Spaces.AbstractSpectralElementSpace,
@@ -276,6 +289,7 @@ function target_coordinates(
     return (longpts, latpts)
 end
 
+islatlonbox(space::Spaces.PointSpace) = false
 islatlonbox(space::Spaces.FiniteDifferenceSpace) = false
 islatlonbox(space::Domains.AbstractDomain) = false
 function islatlonbox(space::Spaces.AbstractSpace)
@@ -471,16 +485,15 @@ function add_space_coordinates_maybe!(
     z_sampling_method,
     depending_on_dimensions,
 )
-    num_points_z = num_points
     name, _... = names
 
     # Add z_reference
     z_reference_dimension_dimension_exists =
-        dimension_exists(nc, name, (num_points_z,))
+        dimension_exists(nc, name, num_points)
 
     if !z_reference_dimension_dimension_exists
         reference_altitudes =
-            target_coordinates(space, num_points_z, z_sampling_method)
+            target_coordinates(space, num_points, z_sampling_method)
         add_dimension!(nc, name, reference_altitudes; units = "m", axis = "Z")
     end
 

--- a/src/netcdf_writer_coordinates.jl
+++ b/src/netcdf_writer_coordinates.jl
@@ -164,7 +164,7 @@ function target_coordinates(
     # We assume H to be 7000, which is a good scale height for the Earth atmosphere
     H_EARTH = 7000
 
-    num_points_z = num_points[]
+    num_points_z = last(num_points)
     FT = Spaces.undertype(space)
     topology = Spaces.topology(space)
     vert_domain = topology.mesh.domain
@@ -195,9 +195,12 @@ function add_space_coordinates_maybe!(
     num_points_z;
     z_sampling_method,
     names = ("z",),
+    interpolated_physical_z = nothing, # Not needed here, but needed for consistency of
+    # interface and dispatch
 )
     name, _... = names
-    z_dimension_exists = dimension_exists(nc, name, (num_points_z,))
+    z_dimension_exists = dimension_exists(nc, name, num_points_z)
+
     if !z_dimension_exists
         zpts = target_coordinates(space, num_points_z, z_sampling_method)
         add_dimension!(nc, name, zpts, units = "m", axis = "Z")
@@ -273,13 +276,20 @@ function target_coordinates(
     return (longpts, latpts)
 end
 
-islatlonbox(domain) = false
+islatlonbox(space::Spaces.FiniteDifferenceSpace) = false
+islatlonbox(space::Domains.AbstractDomain) = false
+function islatlonbox(space::Spaces.AbstractSpace)
+    return islatlonbox(
+        Meshes.domain(Spaces.topology(Spaces.horizontal_space(space))),
+    )
+end
 
 # Box
 function islatlonbox(domain::Domains.RectangleDomain)
     return domain.interval1.coord_max isa Geometry.LatPoint &&
            domain.interval2.coord_max isa Geometry.LongPoint
 end
+
 
 function add_space_coordinates_maybe!(
     nc::NCDatasets.NCDataset,
@@ -416,14 +426,14 @@ function add_space_coordinates_maybe!(
         vdims_names = add_space_coordinates_maybe!(
             nc,
             vertical_space,
-            num_points_vertic;
+            (num_points_vertic,);
             z_sampling_method,
         )
     else
         vdims_names = add_space_coordinates_maybe!(
             nc,
             vertical_space,
-            num_points_vertic,
+            (num_points_vertic,),
             interpolated_physical_z;
             z_sampling_method,
             names = ("z_reference",),

--- a/test/TestTools.jl
+++ b/test/TestTools.jl
@@ -14,6 +14,28 @@ function ColumnCenterFiniteDifferenceSpace(
     context = ClimaComms.SingletonCommsContext();
     FT = Float64,
 )
+    return _column(
+        zelem,
+        ClimaCore.Spaces.CenterFiniteDifferenceSpace,
+        context,
+        FT,
+    )
+end
+
+function ColumnFaceFiniteDifferenceSpace(
+    zelem = 10,
+    context = ClimaComms.SingletonCommsContext();
+    FT = Float64,
+)
+    return _column(
+        zelem,
+        ClimaCore.Spaces.FaceFiniteDifferenceSpace,
+        context,
+        FT,
+    )
+end
+
+function _column(zelem, constructor, context, FT)
     zlim = (FT(0.0), FT(1.0))
     domain = ClimaCore.Domains.IntervalDomain(
         ClimaCore.Geometry.ZPoint(zlim[1]),
@@ -22,8 +44,9 @@ function ColumnCenterFiniteDifferenceSpace(
     )
     mesh = ClimaCore.Meshes.IntervalMesh(domain, nelems = zelem)
     topology = ClimaCore.Topologies.IntervalTopology(context, mesh)
-    return ClimaCore.Spaces.CenterFiniteDifferenceSpace(topology)
+    return constructor(topology)
 end
+
 
 function SphericalShellSpace(;
     radius = 6371.0,

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -8,6 +8,9 @@ import ProfileCanvas
 import NCDatasets
 import ClimaCore
 import ClimaCore.Fields
+import ClimaCore.Spaces
+import ClimaCore.Geometry
+import ClimaComms
 
 import ClimaDiagnostics
 import ClimaDiagnostics.Writers
@@ -253,6 +256,106 @@ end
             # Write a second time, to check consistency
             Writers.write_field!(colwriter, colfield, coldiagnostic, colu, p, t)
         end
+    end
+
+    ###############
+    # Point Space #
+    ###############
+    point_val = 3.14
+    point_space =
+        Spaces.PointSpace(ClimaComms.context(), Geometry.ZPoint(point_val))
+    point_field = Fields.coordinate_field(point_space)
+    point_writer = Writers.NetCDFWriter(point_space, output_dir)
+
+    point_u = (; field = point_field)
+
+    point_diagnostic = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute!,
+            short_name = "ABC",
+        ),
+        output_short_name = "my_short_name_point",
+        output_long_name = "My Long Name Point",
+        output_writer = point_writer,
+    )
+    point_writer.preallocated_output_arrays[point_diagnostic] = [point_val]
+    # No interpolation needed for point space
+    Writers.write_field!(
+        point_writer,
+        point_field,
+        point_diagnostic,
+        point_u,
+        p,
+        t,
+    )
+    # Write a second time
+    Writers.write_field!(
+        point_writer,
+        point_field,
+        point_diagnostic,
+        point_u,
+        p,
+        t,
+    )
+    close(point_writer)
+
+    NCDatasets.NCDataset(joinpath(output_dir, "my_short_name_point.nc")) do nc
+        @test nc["ABC"][:] == [point_val, point_val]
+    end
+
+    ###################
+    # Horizontal Space#
+    ###################
+
+    horizontal_space = ClimaCore.Spaces.level(space, 1)
+    horizontal_field = Fields.coordinate_field(horizontal_space).z
+    horizontal_writer = Writers.NetCDFWriter(
+        horizontal_space,
+        output_dir;
+        num_points = (NUM, 2NUM),
+    )
+    horizontal_u = (; field = horizontal_field)
+
+    horizontal_diagnostic = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute!,
+            short_name = "ABC",
+        ),
+        output_short_name = "my_short_name_horizontal",
+        output_long_name = "My Long Name Point Horizontal",
+        output_writer = horizontal_writer,
+    )
+
+    Writers.interpolate_field!(
+        horizontal_writer,
+        horizontal_field,
+        horizontal_diagnostic,
+        horizontal_u,
+        p,
+        t,
+    )
+    Writers.write_field!(
+        horizontal_writer,
+        horizontal_field,
+        horizontal_diagnostic,
+        horizontal_u,
+        p,
+        t,
+    )
+    # Write a second time
+    Writers.write_field!(
+        horizontal_writer,
+        horizontal_field,
+        horizontal_diagnostic,
+        horizontal_u,
+        p,
+        t,
+    )
+    close(horizontal_writer)
+    NCDatasets.NCDataset(
+        joinpath(output_dir, "my_short_name_horizontal.nc"),
+    ) do nc
+        @test size(nc["ABC"]) == (2, NUM, 2NUM)
     end
 
     ###############

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -6,6 +6,7 @@ using Profile
 using BenchmarkTools
 import ProfileCanvas
 import NCDatasets
+import ClimaCore
 import ClimaCore.Fields
 
 import ClimaDiagnostics
@@ -17,7 +18,7 @@ include("TestTools.jl")
 
 # The temporary directory where we write the file cannot be in /tmp, it has
 # to be on disk
-output_dir = mktempdir(".")
+output_dir = mktempdir(pwd())
 
 @testset "DictWriter" begin
     writer = Writers.DictWriter()
@@ -218,6 +219,41 @@ end
         p,
         t,
     )
+
+    # Check columns
+    if pkgversion(ClimaCore) >= v"0.14.23"
+        # Center space
+        for (i, colspace) in enumerate((
+            ColumnCenterFiniteDifferenceSpace(),
+            ColumnFaceFiniteDifferenceSpace(),
+        ))
+            colfield = Fields.coordinate_field(colspace).z
+
+            colwriter =
+                Writers.NetCDFWriter(colspace, output_dir; num_points = (NUM,))
+            coldiagnostic = ClimaDiagnostics.ScheduledDiagnostic(;
+                variable = ClimaDiagnostics.DiagnosticVariable(;
+                    compute!,
+                    short_name = "ABC",
+                ),
+                output_short_name = "my_short_name_c$(i)",
+                output_long_name = "My Long Name",
+                output_writer = colwriter,
+            )
+            colu = (; colfield)
+            Writers.interpolate_field!(
+                colwriter,
+                colfield,
+                coldiagnostic,
+                colu,
+                p,
+                t,
+            )
+            Writers.write_field!(colwriter, colfield, coldiagnostic, colu, p, t)
+            # Write a second time, to check consistency
+            Writers.write_field!(colwriter, colfield, coldiagnostic, colu, p, t)
+        end
+    end
 
     ###############
     # Performance #


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This provides an alternative to  PR #99 with a different solution to support PointSpaces.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
When a point space results from computating a diagnostic,
interpolation is not run. Additionally, no space coordinate is
added to the output netcdf file.

A constructor for a NetCDF writer on only PointSpaces is also defined,
which sets `num_points`, `z_sampling_method`, and `interpolated_physical_z`
to nothing. 


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Fixed issues in output generation to correctly handle vertical and point spatial configurations.
- **New Features**
	- Enhanced spatial data handling with flexible configuration for diagnostics and improved coordinate processing across varied spatial layouts.
- **Tests**
	- Expanded test coverage and integration checks to ensure robust and consistent behavior across multiple spatial setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->