### PR TITLE
Make write_field! use the type of time

### DIFF
--- a/src/netcdf_writer.jl
+++ b/src/netcdf_writer.jl
@@ -342,10 +342,12 @@ function write_field!(writer::NetCDFWriter, field, diagnostic, u, p, t)
 
     nc = writer.open_files[output_path]
 
+    # Save as associated float if t is ITime
+    TT = typeof(float(t))
     # Define time coordinate
     add_time_maybe!(
         nc,
-        FT;
+        TT;
         units = "s",
         axis = "T",
         standard_name = "time",


### PR DESCRIPTION
closes #105 - When running a simulation with `ITime`, the type of the time dimension in the NetCDF files should be `Float64` and not the type of the space.

This PR changes the type of the time dimension to be the same as `float(t)`. If `t` is an `ITime`, this is a `Float64` which should be the intended behavior.

## TODO
- [x] Test if this work by running a simulation with `Float32` in ClimaAtmos or ClimaCoupler
- [x] Add an unit test
