### PR TITLE
Add `default_num_points`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,14 @@ the interval `[0.0, 10.0]`. If one knows that the data represents a time
 average, then the time of `10.0` is the time average over the interval
 `[0.0, 10.0]`.
 
+### NetCDF writer now defaults to a reasonable number of points
+
+`ClimaDiagnostics.Writers.NetCDF` now has a new default argument that depends on
+the input Space. With this new default, obtained by calling the
+`ClimaDiagnostics.Writers.default_num_points(space)` function, the output
+diagnostics will be sampled with approximately the same resolution as the given
+`space`.
+
 ### Support for `lazy`
 
 Starting version `0.2.13`, `ClimaDiagnostics` supports diagnostic variables

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -50,5 +50,6 @@ ClimaDiagnostics.Writers.NetCDFWriter
 ClimaDiagnostics.Writers.HDF5Writer
 ClimaDiagnostics.Writers.interpolate_field!
 ClimaDiagnostics.Writers.write_field!
+ClimaDiagnostics.Writers.default_num_points
 Base.close
 ```

--- a/src/Writers.jl
+++ b/src/Writers.jl
@@ -15,6 +15,8 @@ Writers can implement:
 """
 module Writers
 
+import ClimaCore
+
 import ..AbstractWriter, ..ScheduledDiagnostic
 import ..ScheduledDiagnostics: output_short_name, output_long_name
 

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -10,6 +10,7 @@ import ClimaCore
 import ClimaCore.Fields
 import ClimaCore.Spaces
 import ClimaCore.Geometry
+import ClimaCore.CommonSpaces
 import ClimaComms
 
 import ClimaDiagnostics
@@ -38,6 +39,51 @@ output_dir = mktempdir(pwd())
 end
 
 @testset "NetCDFWriter" begin
+    @testset "default_num_points" begin
+        @test Writers.default_num_points(
+            CommonSpaces.ExtrudedCubedSphereSpace(;
+                z_elem = 10,
+                z_min = 0,
+                z_max = 1,
+                radius = 10,
+                h_elem = 10,
+                n_quad_points = 4,
+                staggering = CommonSpaces.CellCenter(),
+            ),
+        ) == (120, 60, 10)
+
+        @test Writers.default_num_points(
+            CommonSpaces.SliceXZSpace(;
+                z_elem = 10,
+                x_min = 0,
+                x_max = 1,
+                z_min = 0,
+                z_max = 1,
+                periodic_x = false,
+                n_quad_points = 4,
+                x_elem = 4,
+                staggering = CommonSpaces.CellCenter(),
+            ),
+        ) == (12, 10)
+        @test Writers.default_num_points(
+            CommonSpaces.Box3DSpace(;
+                z_elem = 10,
+                x_min = 0,
+                x_max = 1,
+                y_min = 0,
+                y_max = 1,
+                z_min = 0,
+                z_max = 10,
+                periodic_x = false,
+                periodic_y = false,
+                n_quad_points = 4,
+                x_elem = 3,
+                y_elem = 4,
+                staggering = CommonSpaces.CellCenter(),
+            ),
+        ) == (9, 12, 10)
+    end
+
     space = SphericalShellSpace()
     field = Fields.coordinate_field(space).z
 


### PR DESCRIPTION
`default_num_points` is a new function that automatically computes a tuple with the number of points along each direction of a `space`. `default_num_points` is now the default value for the `NetCDF` writer, so that users will automatically get a reasonably sampled output.
