### PR TITLE
Fix boxes with only one point

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # NEWS
 
+v0.2.14
+-------
+
+## Bug fixes
+
+Fixed the default target coordinates for the `NetCDFWriter` for boxes with only
+one point in the horizontal space.
+
 v0.2.13
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.2.13"
+version = "0.2.14"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/netcdf_writer_coordinates.jl
+++ b/src/netcdf_writer_coordinates.jl
@@ -318,8 +318,17 @@ function target_coordinates(
     xmax = Geometry.tofloat(domain.interval1.coord_max)
     ymin = Geometry.tofloat(domain.interval2.coord_min)
     ymax = Geometry.tofloat(domain.interval2.coord_max)
-    xpts = collect(range(xmin, xmax, num_points_x))
-    ypts = collect(range(ymin, ymax, num_points_y))
+    # Case of box with one single point
+    if num_points_x == 1
+        xpts = [(xmax + xmin) / 2]
+    else
+        xpts = collect(range(xmin, xmax, num_points_x))
+    end
+    if num_points_y == 1
+        ypts = [(ymax + ymin) / 2]
+    else
+        ypts = collect(range(ymin, ymax, num_points_y))
+    end
     return (xpts, ypts)
 end
 


### PR DESCRIPTION
It is not possible to construct ranges when there is only one point. This leads to failures in ClimaAtmos "columns". This commit changes the default target coordinates so that we can also handle this case.
