### PR TITLE
Save time-reduced diagnostics to start of reduction period

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # NEWS
 
+v0.3.0
+-------
+
+- ![][badge-💥breaking]  Reduced NetCDF diagnostics are now timestamped at the start
+  of the reduction period instead of the end. Instantaneous diagnostics are unchanged.
+
 v0.2.14
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.2.15"
+version = "0.3.0"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,6 +4,5 @@ ClimaUtilities = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-ClimaDiagnostics = "0.1, 0.2"
 ClimaUtilities = "0.1.22"
 Documenter = "0.27"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR changes the netcdf writer to save reduced diagnostics to the start of the reduction period, rather than the current time. This change prevents unnecessary date shifting in ClimaAnalysis and would be a breaking change. I'm curious to hear what people think.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->
- Determine start of reduction period from `time_bnds` and `date_bnds` rather than `time` and `date`
- Add tests to check dates for instantaneous, averaged weekly, and averaged monthly diagnostics

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
