### PR TITLE
Use central queue instead of new-central

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: new-central
+  queue: central
   slurm_mem: 8G
   modules: climacommon/2025_03_18
 


### PR DESCRIPTION
This PR updates the queue to use the new filesystem.

Also, the steps in Buildkite is also updated to use central too.