### PR TITLE
(0.3.4) remove SciMLBase; use new CTS interface

### DIFF
--- a/.buildkite/Project.toml
+++ b/.buildkite/Project.toml
@@ -19,7 +19,6 @@ NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 Profile = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 ProfileCanvas = "efd6af41-a80b-495e-886c-e51b0c7d77a3"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
-SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -1,18 +1,18 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
-authors = ["Gabriele Bozzola <gbozzola@caltech.edu>"]
-version = "0.3.3"
+version = "0.3.4"
+authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
+ClimaTimeSteppers = "595c0a79-7f3d-439a-bc5a-b232dc3bde79"
 ClimaUtilities = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 NVTX = "5da4648a-3479-48b8-97b9-01cb529c0a1f"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
-SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 
 [compat]
 Accessors = "0.1.32"
@@ -21,7 +21,7 @@ BenchmarkTools = "1"
 ClimaComms = "0.6.2"
 ClimaCore = "0.14.50"
 ClimaInterpolations = "0.1.1"
-ClimaTimeSteppers = "0.7.21, 0.8.2 - 0.8.8, 0.8.11"
+ClimaTimeSteppers = "0.8.11"
 ClimaUtilities = "0.1.22"
 Dates = "1"
 Documenter = "1"
@@ -34,7 +34,6 @@ OrderedCollections = "1.4"
 Profile = "1"
 ProfileCanvas = "0.1.6"
 SafeTestsets = "0.1"
-SciMLBase = "2.11.0"
 Test = "1"
 julia = "1.10"
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,7 @@ DocMeta.setdocmeta!(
 
 makedocs(
     sitename = "ClimaDiagnostics.jl",
-    authors = "Gabriele Bozzola",
+    authors = "CliMA Contributors",
     format = format,
     pages = pages,
     checkdocs = :exports,

--- a/src/Schedules.jl
+++ b/src/Schedules.jl
@@ -13,7 +13,7 @@ import ..seconds_to_str_short,
     ..period_to_str_short,
     ..period_to_str_long
 
-import SciMLBase
+import ClimaTimeSteppers
 
 import ClimaUtilities.TimeManager: ITime, date, counter, period, epoch
 

--- a/src/clima_diagnostics.jl
+++ b/src/clima_diagnostics.jl
@@ -1,6 +1,6 @@
 import Accessors
 import NVTX
-import SciMLBase
+import ClimaTimeSteppers
 import ClimaComms
 import ClimaCore: Grids, Spaces
 
@@ -515,13 +515,13 @@ function DiagnosticsCallback(diagnostics_handler::DiagnosticsHandler)
     sciml_callback(integrator) =
         orchestrate_diagnostics(integrator, diagnostics_handler)
 
-    # SciMLBase.DiscreteCallback checks if the given condition is true at the end of each
+    # ClimaTimeSteppers.DiscreteCallback checks if the given condition is true at the end of each
     # step. So, we set a condition that is always true, the callback is called at the end of
     # every step. This callback runs `orchestrate_callbacks`, which manages which
     # diagnostics functions to call
     condition = (_, _, _) -> true
 
-    return SciMLBase.DiscreteCallback(condition, sciml_callback)
+    return ClimaTimeSteppers.DiscreteCallback(condition, sciml_callback)
 end
 
 """
@@ -564,7 +564,8 @@ function IntegratorWithDiagnostics(
     continuous_callbacks = integrator.callback.continuous_callbacks
     discrete_callbacks =
         (integrator.callback.discrete_callbacks..., diagnostics_callback)
-    callback = SciMLBase.CallbackSet(continuous_callbacks, discrete_callbacks)
+    callback =
+        ClimaTimeSteppers.CallbackSet(continuous_callbacks, discrete_callbacks)
 
     Accessors.@reset integrator.callback = callback
 

--- a/test/TestTools.jl
+++ b/test/TestTools.jl
@@ -1,6 +1,6 @@
 import Dates
 
-import SciMLBase
+import ClimaTimeSteppers
 
 import ClimaCore
 import ClimaComms
@@ -173,7 +173,7 @@ function create_problem(space; t0 = 0.0, tf = 1.0, dt = 1e-3)
         @. dY.my_var = p.tau * Y.my_var
     end
 
-    prob = SciMLBase.ODEProblem(
+    prob = ClimaTimeSteppers.ODEProblem(
         ClimaTimeSteppers.ClimaODEFunction(T_exp! = exp_tendency!),
         Y,
         (t0, tf),

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -4,7 +4,7 @@ import ClimaDiagnostics.Schedules
 import ClimaDiagnostics.ScheduledDiagnostics
 import ClimaDiagnostics.Writers
 
-import SciMLBase
+import ClimaTimeSteppers
 
 include("TestTools.jl")
 
@@ -21,7 +21,7 @@ include("TestTools.jl")
         @. dY.my_var = p.tau * Y.my_var
     end
 
-    prob = SciMLBase.ODEProblem(
+    prob = ClimaTimeSteppers.ODEProblem(
         ClimaTimeSteppers.ClimaODEFunction(T_exp! = exp_tendency!),
         Y,
         (t0, tf),
@@ -65,7 +65,7 @@ include("TestTools.jl")
 
     diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
-    prob = SciMLBase.ODEProblem(
+    prob = ClimaTimeSteppers.ODEProblem(
         ClimaTimeSteppers.ClimaODEFunction(T_exp! = exp_tendency!),
         Y,
         (t0, tf),
@@ -73,7 +73,7 @@ include("TestTools.jl")
     )
     algo = ClimaTimeSteppers.ExplicitAlgorithm(ClimaTimeSteppers.RK4())
 
-    SciMLBase.solve(prob, algo, dt = dt, callback = diag_cb)
+    ClimaTimeSteppers.solve(prob, algo, dt = dt, callback = diag_cb)
 
     @test length(keys(dict_writer.dict[short_name])) ==
           convert(Int, 1 + (tf - t0) / dt)
@@ -102,7 +102,7 @@ include("TestTools.jl")
 
     diag_cb = ClimaDiagnostics.DiagnosticsCallback(diagnostic_handler)
 
-    prob = SciMLBase.ODEProblem(
+    prob = ClimaTimeSteppers.ODEProblem(
         ClimaTimeSteppers.ClimaODEFunction(T_exp! = exp_tendency!),
         Y,
         (t0, tf),
@@ -110,7 +110,7 @@ include("TestTools.jl")
     )
     algo = ClimaTimeSteppers.ExplicitAlgorithm(ClimaTimeSteppers.RK4())
 
-    SciMLBase.solve(prob, algo, dt = dt, callback = diag_cb)
+    ClimaTimeSteppers.solve(prob, algo, dt = dt, callback = diag_cb)
 
     @test length(keys(dict_writer.dict[short_name])) ==
           convert(Int, (tf - t0) / 5dt)

--- a/test/integration_test.jl
+++ b/test/integration_test.jl
@@ -2,7 +2,7 @@ using Test
 using Profile
 using ProfileCanvas
 
-import SciMLBase
+import ClimaTimeSteppers
 import NCDatasets
 
 import ClimaDiagnostics
@@ -180,7 +180,7 @@ function setup_integrator(
     ]
 
     return ClimaDiagnostics.IntegratorWithDiagnostics(
-        SciMLBase.init(args...; kwargs...),
+        ClimaTimeSteppers.init(args...; kwargs...),
         scheduled_diagnostics,
     )
 end
@@ -224,7 +224,7 @@ for (space, space_name, written_space_dims) in spaces_test_list
                 integrator =
                     setup_integrator(output_dir; context, space, dict_writer)
 
-                SciMLBase.solve!(integrator)
+                ClimaTimeSteppers.solve!(integrator)
 
                 if ClimaComms.iamroot(context)
                     NCDatasets.NCDataset(
@@ -284,14 +284,14 @@ end
 
         # Flame
         integrator = setup_integrator(output_dir; context)
-        prof = Profile.@profile SciMLBase.solve!(integrator)
+        prof = Profile.@profile ClimaTimeSteppers.solve!(integrator)
         ClimaComms.iamroot(context) && (results = Profile.fetch())
         ClimaComms.iamroot(context) &&
             ProfileCanvas.html_file("flame.html", results)
 
         # Allocations
         integrator = setup_integrator(output_dir; context)
-        prof = Profile.Allocs.@profile SciMLBase.solve!(integrator)
+        prof = Profile.Allocs.@profile ClimaTimeSteppers.solve!(integrator)
         ClimaComms.iamroot(context) && (results = Profile.Allocs.fetch())
         ClimaComms.iamroot(context) &&
             (allocs = ProfileCanvas.view_allocs(results))
@@ -358,7 +358,7 @@ function setup_integrator_with_pressure_diags(output_dir, space)
     close(writer)
 
     return ClimaDiagnostics.IntegratorWithDiagnostics(
-        SciMLBase.init(args...; kwargs...),
+        ClimaTimeSteppers.init(args...; kwargs...),
         scheduled_diagnostics,
     )
 end
@@ -375,7 +375,7 @@ for (space, space_name) in spaces_test_list
             output_dir = ClimaComms.bcast(context, output_dir)
 
             integrator = setup_integrator_with_pressure_diags(output_dir, space)
-            SciMLBase.solve!(integrator)
+            ClimaTimeSteppers.solve!(integrator)
 
             filenames = ["yo_inst_pressure.nc", "yo_max_pressure.nc"]
             for filename in filenames

--- a/test/schedules.jl
+++ b/test/schedules.jl
@@ -1,5 +1,5 @@
 using Test
-import SciMLBase
+import ClimaTimeSteppers
 
 import Dates
 
@@ -24,7 +24,7 @@ include("TestTools.jl")
     scheduled_func = DivisorSchedule(divisor)
     @test "$scheduled_func" == "2it"
 
-    callback_everystep = SciMLBase.DiscreteCallback(
+    callback_everystep = ClimaTimeSteppers.DiscreteCallback(
         (_, _, integrator) -> scheduled_func(integrator),
         callback_func0,
     )
@@ -38,7 +38,7 @@ include("TestTools.jl")
 
     expected_called = convert(Int, (tf - t0) / (divisor * dt))
 
-    SciMLBase.solve(args...; kwargs..., callback = callback_everystep)
+    ClimaTimeSteppers.solve(args...; kwargs..., callback = callback_everystep)
 
     @test called[] == expected_called
 
@@ -67,11 +67,11 @@ include("TestTools.jl")
     t_last2 = 0.1
     scheduled_func2 = EveryDtSchedule(dt_callback2; t_last = t_last2)
 
-    callback_dt = SciMLBase.DiscreteCallback(
+    callback_dt = ClimaTimeSteppers.DiscreteCallback(
         (_, _, integrator) -> scheduled_func(integrator),
         callback_func,
     )
-    callback_dt2 = SciMLBase.DiscreteCallback(
+    callback_dt2 = ClimaTimeSteppers.DiscreteCallback(
         (_, _, integrator) -> scheduled_func2(integrator),
         callback_func2,
     )
@@ -81,10 +81,10 @@ include("TestTools.jl")
     expected_called = convert(Int, (tf - t0) / dt_callback)
     expected_called2 = convert(Int, floor((tf - t0 - t_last2) / dt_callback2))
 
-    SciMLBase.solve(
+    ClimaTimeSteppers.solve(
         args...;
         kwargs...,
-        callback = SciMLBase.CallbackSet(callback_dt, callback_dt2),
+        callback = ClimaTimeSteppers.CallbackSet(callback_dt, callback_dt2),
     )
 
     @test called[] == expected_called
@@ -180,7 +180,7 @@ include("TestTools.jl")
     )
     @test "$scheduled_func_month" == "1M"
 
-    callback_dt_month = SciMLBase.DiscreteCallback(
+    callback_dt_month = ClimaTimeSteppers.DiscreteCallback(
         (_, _, integrator) -> scheduled_func_month(integrator),
         callback_func_month,
     )
@@ -194,10 +194,10 @@ include("TestTools.jl")
     expected_called_month =
         convert(Int, floor((tf - t0) / dt_callback_month_in_s))
 
-    SciMLBase.solve(
+    ClimaTimeSteppers.solve(
         args...;
         kwargs...,
-        callback = SciMLBase.CallbackSet(callback_dt_month),
+        callback = ClimaTimeSteppers.CallbackSet(callback_dt_month),
     )
 
     @test called_month[] == expected_called_month


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Update to use new ClimaTimeSteppers interface implemented in https://github.com/CliMA/ClimaTimeSteppers.jl/tree/ts/cts-refactor

~~The tests are failing because ~~they need ClimaTimeSteppers#ts/cts-refactor and the Manifest isn't checked in, but they passed locally.~~ ~~we need to use ClimaTimeSteppers v0.10.11~~ the main branch of ClimaLand still creates SciMLBase callbacks~~ The tests are now passing.


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
