### PR TITLE
Support NamedTuple-valued diagnostics

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,39 @@
 main
 -------
 
+v0.3.6
+------
+
+## Features
+
+### Support `NamedTuple`-valued diagnostics (one variable per component)
+
+A `DiagnosticVariable` whose `compute`/`compute!` returns a `Field` whose
+pointwise element type is a `NamedTuple` is now automatically written as one
+scalar diagnostic per (possibly nested) component. A single compute function
+(for example, the per-process tendencies of a parameterization in a debug
+mode) therefore fans out into per-component diagnostics with no extra code.
+
+For the `NetCDFWriter`, each component becomes its own variable named
+`<short_name>_<component_path>` (e.g. `clw_tend_cond`, `clw_tend_evap`),
+written through the usual scalar path; scalar diagnostics are unchanged. The
+`HDF5Writer` and `DictWriter` store the `NamedTuple` field whole, as before.
+
+`units` (and `long_name`) may now be specified per component, either as a
+`NamedTuple` mapping each component to its units, or as a function
+`property_chain -> units`. A plain `String` is still applied to every
+component.
+
+```julia
+var = DiagnosticVariable(;
+    short_name = "clw_tend",
+    long_name = "cloud liquid water tendency",
+    units = (; cond = "kg kg^-1 s^-1", evap = "kg kg^-1 s^-1"),
+    compute = (state, cache, time) -> state.microphysics_tendencies,
+)
+```
+
+See the "NamedTuple diagnostics" page in the documentation for details.
 
 v0.3.5
 ------

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaDiagnostics"
 uuid = "1ecacbb8-0713-4841-9a07-eb5aa8a2d53f"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["CliMA Contributors <clima-software@caltech.edu>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ pages = [
     "Overview" => "index.md",
     "User guide" => "user_guide.md",
     "Saving output" => "writers.md",
+    "NamedTuple diagnostics" => "namedtuple_diagnostics.md",
     "How to add ClimaDiagnostics to a package" => "developer_guide.md",
     "Internals" => "internals.md",
     "APIs" => "api.md",

--- a/docs/src/namedtuple_diagnostics.md
+++ b/docs/src/namedtuple_diagnostics.md
@@ -1,0 +1,177 @@
+# NamedTuple diagnostics (one variable per component)
+
+Sometimes a single computation naturally produces *several* related scalar
+fields at once. A typical example is the individual process-level tendencies of a
+parameterization as a `NamedTuple` at every grid point (e.g. condensation,
+evaporation, accretion, ...).
+
+`ClimaDiagnostics` lets you expose such a computation as a single
+`DiagnosticVariable` whose `compute`/`compute!` returns a `Field` whose
+*pointwise element type is a `NamedTuple`*. Each entry of the `NamedTuple` is
+then written automatically as its own scalar diagnostic — you do not need to
+write one `compute` function per component.
+
+```julia
+using ClimaDiagnostics
+
+# `cache.microphysics_tendencies` is a Field of NamedTuples, e.g. with element
+# type @NamedTuple{cond::FT, evap::FT, accr::FT}
+compute_micro(state, cache, time) = cache.microphysics_tendencies
+
+var = DiagnosticVariable(;
+    # `short_name`/`long_name` are a *stem*, not the name of a single
+    # variable: one diagnostic is produced per `NamedTuple` entry.
+    short_name = "clw_tend",
+    long_name = "cloud liquid water tendency",
+    units = "kg kg⁻¹ s⁻¹",
+    compute = compute_micro,
+)
+```
+
+This single `var` does **not** describe one variable called `clw_tend`. It is
+a recipe that fans out into one diagnostic per `NamedTuple` entry. With a
+`NetCDFWriter` you get three variables,
+
+| variable        | `long_name`                          | `units`       |
+|-----------------|--------------------------------------|---------------|
+| `clw_tend_cond` | `cloud liquid water tendency (cond)` | `kg kg⁻¹ s⁻¹` |
+| `clw_tend_evap` | `cloud liquid water tendency (evap)` | `kg kg⁻¹ s⁻¹` |
+| `clw_tend_accr` | `cloud liquid water tendency (accr)` | `kg kg⁻¹ s⁻¹` |
+
+The per-component part of each name (`cond`, `evap`, `accr`) comes from the
+keys of the `NamedTuple` your `compute` returns — you control it there, not
+through `short_name`. `short_name`/`long_name` stay single strings: the stem
+groups the components under a common prefix and (for the `NetCDFWriter`) also
+names the single output file.
+
+Wrapping `var` in a `ScheduledDiagnostic` and attaching a `NetCDFWriter` is
+exactly the same as for an ordinary scalar diagnostic — see the [user
+guide](@ref user_guide_header). Nothing else in the pipeline changes:
+reductions, time averaging, schedules, and `ScheduledDiagnostic`s all work
+unchanged (the accumulation operates element-wise on the `NamedTuple`).
+
+## What gets written
+
+The behavior depends on the writer, because only the `NetCDFWriter` needs to
+flatten the field (see [Why splitting happens at the writer](@ref)).
+
+### `NetCDFWriter`
+
+The diagnostic is split into **one scalar NetCDF variable per component**, all
+written to the same file. Each variable is named
+`<short_name>_<component_path>`. With the `var` above you get the variables
+
+```
+clw_tend_cond
+clw_tend_evap
+clw_tend_accr
+```
+
+each interpolated and written exactly like an ordinary scalar diagnostic
+(same dimensions, `time`/`date` bounds, reductions, ...). A plain scalar
+diagnostic is unaffected: it keeps its bare `short_name` with no suffix.
+
+### `HDF5Writer` and `DictWriter`
+
+These writers do not interpolate, so they store the `NamedTuple` field
+**whole and unsplit** — `DictWriter` keeps the `Field` as-is, and `HDF5Writer`
+writes it as a single dataset that can be read back with `ClimaCore`'s
+`InputOutput` module (the same mechanism used for the model state). No
+per-component splitting happens.
+
+## Per-component metadata
+
+Only `units` can be specified per component. It accepts three forms:
+
+- a `String` is applied to **every** component (the default, unchanged behavior);
+- a `NamedTuple` maps each component to its own units string (it may mirror
+  the nesting; a flat `NamedTuple` keyed by the leaf name also works);
+- a function `property_chain -> units` is called for each component.
+  `property_chain` is the `Tuple` identifying the component (`Symbol`s for
+  `NamedTuple` field names, `Int`s for tuple-element indices, e.g.
+  `(:warm, :autoconversion)`); the function should return the units string,
+  or `nothing` if that component has no units. This is the most general form
+  and is handy for dynamically generated or deeply nested results.
+
+```julia
+# All three forms are valid:
+units = "kg kg⁻¹ s⁻¹"
+units = (; cond = "kg kg⁻¹ s⁻¹", evap = "kg kg⁻¹ s⁻¹")
+units = chain -> "kg kg⁻¹ s⁻¹"
+```
+
+`short_name` and `long_name` are deliberately single strings, **not**
+per-component: `short_name` is a stem that groups the components and names the
+output file, and the per-component identity is already carried by the
+`NamedTuple` keys (the property chain). The `long_name` of each NetCDF
+variable is the diagnostic's `long_name` with the component path appended,
+e.g. `"cloud liquid water tendency (cond)"`.
+
+For `HDF5Writer` (which keeps the field whole) the per-component units are
+flattened into a single descriptive `variable_units` attribute, e.g.
+`"cond: kg kg⁻¹ s⁻¹, evap: kg kg⁻¹ s⁻¹, accr: kg kg⁻¹ s⁻¹"`.
+
+### Misspecified units
+
+If a component has no units, its units field is left empty (an empty NetCDF
+`units` attribute / an empty value in the `HDF5Writer`'s flattened string),
+and a one-time warning listing those components is emitted when the
+`DiagnosticsHandler` is constructed.
+
+A component "has no units" when it resolves to `nothing`: a `NamedTuple` with
+no entry for it, or a `Function` that returned `nothing` for it. An
+explicitly empty value is treated as deliberate and is **not** warned about:
+a `NamedTuple` entry set to `""`, or a `Function` returning `""`. A `String`
+is never warned (it is shared by every component, and the default `units` is
+`""`).
+
+## Nested `NamedTuple`s
+
+Nesting is supported and flattened recursively. A field with element type
+
+```julia
+@NamedTuple{warm::@NamedTuple{au::FT, ac::FT}, tot::FT}
+```
+
+and `short_name = "proc"` produces the NetCDF variables
+
+```
+proc_warm_au
+proc_warm_ac
+proc_tot
+```
+
+The corresponding property chains are `(:warm, :au)`, `(:warm, :ac)`, and
+`(:tot,)`; these are exactly the chains passed to a `units` function and used
+to build the flat-`NamedTuple` lookup.
+
+## Point and column spaces
+
+Single-column and `PointSpace` diagnostics are supported too: the
+`NetCDFWriter` splits the `NamedTuple` into one scalar variable per component
+on these spaces as well (no interpolation is performed).
+
+## Reductions and averaging
+
+Temporal reductions work without any special handling. For example, a monthly
+average of a `NamedTuple` diagnostic accumulates and averages each component
+independently, and then the averaged components are written as separate
+variables, just like the instantaneous case.
+
+## Why splitting happens at the writer
+
+NetCDF (as used here, following the CF conventions) stores plain numeric
+arrays with named dimensions; it has no notion of a "`NamedTuple` variable".
+More importantly, the `NetCDFWriter` resamples every field onto a rectangular
+grid using `ClimaCore`'s remapper, and the remapper operates on scalar fields
+only.
+
+For this reason a `NamedTuple` diagnostic is split into its scalar components
+*before* remapping: each component is a zero-copy scalar view, remapped and
+written through the ordinary scalar path. Everything upstream of the writer
+(storage, accumulators, reductions, the averaging hook) already works on
+`NamedTuple`-valued fields directly, so the split is confined to the writer
+boundary and scalar diagnostics are completely unaffected.
+
+The `HDF5Writer`/`DictWriter` do not remap, so they keep the field whole and
+need no splitting.

--- a/src/DiagnosticVariables.jl
+++ b/src/DiagnosticVariables.jl
@@ -49,7 +49,12 @@ Keyword arguments
 - `standard_name`: Standard name, as in
                    http://cfconventions.org/Data/cf-standard-names/71/build/cf-standard-name-table.html
 
-- `units`: Physical units of the variable.
+- `units`: Physical units of the variable. For a diagnostic whose `compute`/`compute!`
+           returns a `Field` of `NamedTuple`s (one scalar diagnostic per entry), `units`
+           may also be a `NamedTuple` mapping each component to its own units string, or a
+           function `property_chain -> units` (where `property_chain` is a tuple of
+           `Symbol`s identifying the component, e.g. `(:warm, :autoconversion)`). A plain
+           string is applied to every component.
 
 - `comments`: More verbose explanation of what the variable is, or comments related to how
               it is defined or computed.
@@ -63,7 +68,7 @@ struct DiagnosticVariable{
     short_name::String
     long_name::String
     standard_name::String
-    units::String
+    units::Union{AbstractString, NamedTuple, Function}
     comments::String
 end
 
@@ -195,5 +200,95 @@ function descriptive_long_name(
         suffix = "Instantaneous"
     end
     return "$(var), $(suffix)"
+end
+
+"""
+    component_units(units, property_chain)
+
+Resolve the units for one scalar component of a (possibly composite,
+i.e. `NamedTuple`-valued) diagnostic field.
+
+`property_chain` is the `Tuple` of accessors identifying the component, as
+produced by `ClimaCore.Fields.property_chains`: `Symbol`s for `NamedTuple`
+field names and `Int`s for `Tuple`/`NTuple` element indices. Its length is
+the nesting depth, and it is the empty tuple `()` for a plain scalar field.
+
+- a `String` (or any `AbstractString`) is used for every component;
+- a `Function` is called as `units(property_chain)`; it should return the
+  units string, or `nothing` if the component has no units;
+- a `NamedTuple` is descended following `property_chain` (supporting nested
+  `NamedTuple`s); as a convenience, a flat `NamedTuple` keyed by the leaf
+  name is also accepted.
+
+Returns `nothing` when there is no entry for the component (callers turn this
+into an empty units field; [`units_warnings`](@ref) reports it). An entry
+explicitly set to `""` is returned as `""`: a deliberate empty value, not a
+mismatch.
+"""
+component_units(units::AbstractString, _) = units
+component_units(units, property_chain) = units(property_chain)
+function component_units(units::NamedTuple, property_chain)
+    isempty(property_chain) && return units
+    key = first(property_chain)
+    rest = Base.tail(property_chain)
+    # `haskey(::NamedTuple, ::Int)` is positional indexing — an `Int` chain
+    # element (a `Tuple`/`NTuple` index) must NOT match a `NamedTuple` key.
+    # Guard both branches on `Symbol`; a non-`Symbol` resolves to `nothing`.
+    if key isa Symbol && haskey(units, key)
+        sub = getfield(units, key)
+        return isempty(rest) ? sub : component_units(sub, rest)
+    end
+    leaf = last(property_chain)
+    if leaf isa Symbol && haskey(units, leaf)
+        return getfield(units, leaf)
+    end
+    return nothing
+end
+
+"""
+    units_warnings(units, property_chains; name = "")
+
+Emit a one-time warning listing the components in `property_chains` whose
+`units` resolve to `nothing` (no entry) - their units field is left empty.
+
+A `String` never resolves to `nothing` (it is shared by every component, and
+the default `units` is `""`), so it is implicitly exempt. For a `Function`,
+returning `nothing` signals "no units" (warned) while returning `""` is a
+deliberate empty value (not warned); likewise a `NamedTuple` entry explicitly
+set to `""` is deliberate and not warned about.
+
+Intended to be called once per diagnostic (at `DiagnosticsHandler`
+construction).
+"""
+function units_warnings(units, property_chains; name = "")
+    no_units =
+        filter(c -> isnothing(component_units(units, c)), property_chains)
+    isempty(no_units) && return nothing
+    label = isempty(name) ? "" : " for \"$name\""
+    components = join((join(string.(c), '.') for c in no_units), ", ")
+    @warn "Missing `units`$label for component(s): $components. \
+           Their units attribute will be left empty."
+    return nothing
+end
+
+"""
+    units_attribute(units, property_chains)
+
+Render `units` as a single string, for a writer that stores a (possibly
+`NamedTuple`-valued) field as one dataset and therefore has a single `units`
+attribute for the whole field (e.g. the `HDF5Writer`).
+
+A plain `String` is returned unchanged. Otherwise the units of every component
+in `property_chains` are resolved with [`component_units`](@ref) and joined,
+e.g. `"warm.au: 1/s, warm.ac: 1/s, tot: 1/s"`. This keeps the attribute
+consistent with the per-variable `units` the `NetCDFWriter` writes.
+"""
+units_attribute(units::AbstractString, _) = units
+function units_attribute(units, property_chains)
+    labeled = map(property_chains) do chain
+        u = something(component_units(units, chain), "")
+        "$(join(string.(chain), '.')): $u"
+    end
+    return join(labeled, ", ")
 end
 end

--- a/src/Writers.jl
+++ b/src/Writers.jl
@@ -19,6 +19,7 @@ import ClimaCore
 
 import ..AbstractWriter, ..ScheduledDiagnostic
 import ..ScheduledDiagnostics: output_short_name, output_long_name
+import ..DiagnosticVariables: component_units, units_attribute
 
 function write_field!(writer::AbstractWriter, field, diagnostic, u, p, t)
     # Nothing to be done here :)

--- a/src/clima_diagnostics.jl
+++ b/src/clima_diagnostics.jl
@@ -2,13 +2,13 @@ import Accessors
 import NVTX
 import ClimaTimeSteppers
 import ClimaComms
-import ClimaCore: Grids, Spaces
+import ClimaCore: Fields, Grids, Spaces
 
 import ..Interpolators:
     interpolate_to_pressure_coords, interpolate_to_pressure_coords!, update!
 import .Schedules: DivisorSchedule, EveryDtSchedule
-import .Writers:
-    interpolate_field!, write_field!, sync, AbstractWriter, NetCDFWriter
+import .Writers: interpolate_field!, write_field!, sync, AbstractWriter
+import .Writers: NetCDFWriter, set_pointspace_output!
 
 import ..Writers: AbstractZSamplingMethod, RealPressureLevelsMethod
 
@@ -111,6 +111,16 @@ function DiagnosticsHandler(scheduled_diagnostics, Y, p, t; dt = nothing)
         isa_time_reduction = !isnothing(diag.reduction_time_func)
 
         out_field = compute_field(diag, Y, p, t)
+        # Warn once about misspecified per-component `units`. Guarded because
+        # on scalar / `Geometry.AxisVector` eltypes the property-chain walk
+        # would emit false positives.
+        if eltype(out_field) <: NamedTuple
+            DiagnosticVariables.units_warnings(
+                diag.variable.units,
+                Fields.property_chains(out_field);
+                name = diag.variable.short_name,
+            )
+        end
         # We call `copy` to acquire ownership of the data in case compute! returned a
         # reference.
         push!(storage, copy(out_field))
@@ -123,8 +133,7 @@ function DiagnosticsHandler(scheduled_diagnostics, Y, p, t; dt = nothing)
                 # netCDFWriter expects diagnostic to be in preallocated_output_arrays
                 if diag.output_writer isa NetCDFWriter &&
                    ClimaComms.iamroot(ClimaComms.context(storage[i]))
-                    diag.output_writer.preallocated_output_arrays[diag] =
-                        copy(parent(storage[i]))
+                    set_pointspace_output!(diag.output_writer, diag, storage[i])
                 end
             else
                 interpolate_field!(
@@ -450,8 +459,11 @@ NVTX.@annotate function orchestrate_diagnostics(
             if diag.output_writer isa NetCDFWriter && ClimaComms.iamroot(
                 ClimaComms.context(diagnostic_handler.storage[diag_index]),
             )
-                diag.output_writer.preallocated_output_arrays[diag] =
-                    copy(parent(diagnostic_handler.storage[diag_index]))
+                set_pointspace_output!(
+                    diag.output_writer,
+                    diag,
+                    diagnostic_handler.storage[diag_index],
+                )
             end
         else
             interpolate_field!(

--- a/src/hdf5_writer.jl
+++ b/src/hdf5_writer.jl
@@ -1,5 +1,5 @@
 import ClimaComms
-import ClimaCore: InputOutput, Spaces
+import ClimaCore: Fields, InputOutput, Spaces
 import ClimaUtilities.TimeManager: ITime
 
 import NVTX
@@ -66,7 +66,8 @@ NVTX.@annotate function write_field!(
         "time" => time,
         "short_name" => diagnostic.output_short_name,
         "long_name" => diagnostic.output_long_name,
-        "variable_units" => var.units,
+        "variable_units" =>
+            units_attribute(var.units, Fields.property_chains(field)),
         "standard_variable_name" => var.standard_name,
     )
 

--- a/src/netcdf_writer.jl
+++ b/src/netcdf_writer.jl
@@ -64,8 +64,9 @@ struct NetCDFWriter{
     sampled."""
     z_sampling_method::ZSM
 
-    """Areas of memory preallocated where the interpolation output is saved. Only the root
-    process uses this."""
+    """Areas of memory preallocated where the interpolation output is saved.
+    Per diagnostic: a single array for a scalar field, or a `Dict(chain => array)`
+    for a `Field` of `NamedTuple`s. Only the root process uses this."""
     preallocated_output_arrays::DI
 
     """Callable that determines when to call NetCDF.sync. NetCDF.sync is needed to flush the
@@ -247,10 +248,7 @@ function NetCDFWriter(
             maybe_move_to_cpu(interpolate(remapper, coords_z))
     end
 
-    preallocated_arrays =
-        ClimaComms.iamroot(comms_ctx) ?
-        Dict{ScheduledDiagnostic, ClimaComms.array_type(space)}() :
-        Dict{ScheduledDiagnostic, Nothing}()
+    preallocated_arrays = Dict{ScheduledDiagnostic, Any}()
 
     unsynced_datasets = Set{NCDatasets.NCDataset}()
 
@@ -339,10 +337,7 @@ function NetCDFWriter(
             maybe_move_to_cpu(interpolate(remapper, coords_z))
     end
 
-    preallocated_arrays =
-        ClimaComms.iamroot(comms_ctx) ?
-        Dict{ScheduledDiagnostic, ClimaComms.array_type(space)}() :
-        Dict{ScheduledDiagnostic, Nothing}()
+    preallocated_arrays = Dict{ScheduledDiagnostic, Any}()
 
     unsynced_datasets = Set{NCDatasets.NCDataset}()
     return NetCDFWriter{
@@ -389,10 +384,7 @@ function NetCDFWriter(
     kwargs...,
 )
     comms_ctx = ClimaComms.context(space)
-    preallocated_arrays =
-        ClimaComms.iamroot(comms_ctx) ?
-        Dict{ScheduledDiagnostic, ClimaComms.array_type(space)}() :
-        Dict{ScheduledDiagnostic, Nothing}()
+    preallocated_arrays = Dict{ScheduledDiagnostic, Any}()
     unsynced_datasets = Set{NCDatasets.NCDataset}()
     horizontal_method = SpectralElementRemapping() # no horizontal remapping for point space
     return NetCDFWriter{
@@ -425,6 +417,61 @@ function NetCDFWriter(
         init_time,
         horizontal_method,
     )
+end
+
+# A diagnostic whose computed `Field` has a `NamedTuple` element type is written
+# as one scalar NetCDF variable per (possibly nested) component. The remapper is
+# scalar-only, so we always split into scalar sub-fields *before* interpolating.
+
+"""
+    output_property_chains(field)
+
+Return the list of property chains identifying the scalar components to write
+for `field`. For a scalar field this is a single empty chain `()`; for a
+`Field` of `NamedTuple`s it is one chain per (possibly nested) leaf.
+"""
+output_property_chains(field) =
+    eltype(field) <: NamedTuple ? Fields.property_chains(field) : ((),)
+
+"""
+    component_field(field, property_chain)
+
+Return the scalar sub-`Field` of `field` identified by `property_chain` (the
+field itself when the chain is empty).
+"""
+component_field(field, ::Tuple{}) = field
+component_field(field, property_chain) =
+    Fields.single_field(field, property_chain)
+
+# NetCDF variable name for a component: the bare short name for a scalar
+# diagnostic (unchanged), or `<short_name>_<chain...>` for a component.
+component_short_name(short_name, ::Tuple{}) = short_name
+component_short_name(short_name, property_chain) =
+    string(short_name, "_", join(string.(property_chain), "_"))
+
+component_long_name(long_name, ::Tuple{}) = long_name
+component_long_name(long_name, property_chain) =
+    string(long_name, " (", join(string.(property_chain), "."), ")")
+
+"""
+    set_pointspace_output!(writer::NetCDFWriter, diagnostic, field)
+
+Populate `writer.preallocated_output_arrays` for a `PointSpace` `field`, which
+needs no remapping. `NamedTuple`-valued fields are split into one entry per
+scalar component (keyed by property chain), mirroring [`interpolate_field!`].
+"""
+function set_pointspace_output!(writer::NetCDFWriter, diagnostic, field)
+    if eltype(field) <: NamedTuple
+        store = Dict{Tuple, Any}()
+        for property_chain in Fields.property_chains(field)
+            store[property_chain] =
+                copy(parent(component_field(field, property_chain)))
+        end
+        writer.preallocated_output_arrays[diagnostic] = store
+    else
+        writer.preallocated_output_arrays[diagnostic] = copy(parent(field))
+    end
+    return nothing
 end
 
 """
@@ -509,7 +556,22 @@ NVTX.@annotate function interpolate_field!(
     #
     # The first time we call this, we call interpolate and allocate a new array.
     # Future calls are in-place
-    if haskey(writer.preallocated_output_arrays, diagnostic)
+    if eltype(field) <: NamedTuple
+        # One scalar sub-field per (possibly nested) NamedTuple component.
+        # The remapper is shared (it only depends on the space).
+        if !haskey(writer.preallocated_output_arrays, diagnostic)
+            writer.preallocated_output_arrays[diagnostic] = Dict{Tuple, Any}()
+        end
+        store = writer.preallocated_output_arrays[diagnostic]
+        for property_chain in Fields.property_chains(field)
+            sub = component_field(field, property_chain)
+            if haskey(store, property_chain)
+                interpolate!(store[property_chain], remapper, sub)
+            else
+                store[property_chain] = interpolate(remapper, sub)
+            end
+        end
+    elseif haskey(writer.preallocated_output_arrays, diagnostic)
         interpolate!(
             writer.preallocated_output_arrays[diagnostic],
             remapper,
@@ -564,13 +626,8 @@ NVTX.@annotate function write_field!(
 
     maybe_move_to_cpu =
         ClimaComms.device(field) isa ClimaComms.CUDADevice ? Array : identity
-    interpolated_field =
-        maybe_move_to_cpu(writer.preallocated_output_arrays[diagnostic])
-
-    if space isa Spaces.PointSpace
-        # If the space is a point space, we have to remove the singleton dimension
-        interpolated_field = interpolated_field[]
-    end
+    # Per-component `Dict` for NamedTuple diagnostics; an array for scalars.
+    prealloc = writer.preallocated_output_arrays[diagnostic]
 
     FT = Spaces.undertype(space)
 
@@ -645,20 +702,6 @@ NVTX.@annotate function write_field!(
         )
     end
 
-    (v, temporal_size) = get_var_and_t_index!(
-        nc,
-        FT,
-        writer,
-        interpolated_field,
-        diagnostic,
-        dim_names,
-        start_date,
-    )
-
-    # We need to write to the next position after what we read from the data (or the first
-    # position ever if we are writing the file for the first time)
-    time_index = temporal_size + 1
-
     # Time handling for reduced vs instantaneous diagnostics:
     # - For reduced diagnostics: store time as the START of the reduction
     #   period, with time_bnds showing [start, end] of the period.
@@ -666,17 +709,56 @@ NVTX.@annotate function write_field!(
     #   time_bnds showing [previous_time, current_time].
     isa_time_reduction = !isnothing(diagnostic.reduction_time_func)
     (; init_time) = writer
-    append_temporal_values!(
-        nc,
-        isa_time_reduction,
-        t,
-        start_date,
-        init_time,
-        time_index,
-    )
-
+    var = diagnostic.variable
     colons = ntuple(_ -> Colon(), length(dim_names))
-    v[time_index, colons...] = interpolated_field
+
+    # All components share the `time` dimension, so the time coordinate is
+    # appended once per write, not once per component.
+    time_index = nothing
+    for property_chain in output_property_chains(field)
+        arr = prealloc isa AbstractDict ? prealloc[property_chain] : prealloc
+        interpolated_field = maybe_move_to_cpu(arr)
+        if space isa Spaces.PointSpace
+            # Point space: remove the singleton dimension
+            interpolated_field = interpolated_field[]
+        end
+
+        varname = component_short_name(var.short_name, property_chain)
+        long_name =
+            component_long_name(output_long_name(diagnostic), property_chain)
+        units =
+            string(something(component_units(var.units, property_chain), ""))
+
+        (v, temporal_size) = get_var_and_t_index!(
+            nc,
+            FT,
+            writer,
+            interpolated_field,
+            diagnostic,
+            varname,
+            long_name,
+            units,
+            dim_names,
+            start_date,
+        )
+
+        # Time index captured once before any component is written: each
+        # write extends the shared unlimited `time` dim, which would
+        # otherwise inflate the index seen by later components.
+        if isnothing(time_index)
+            time_index = temporal_size + 1
+            append_temporal_values!(
+                nc,
+                isa_time_reduction,
+                t,
+                start_date,
+                init_time,
+                time_index,
+            )
+        end
+
+        v[time_index, colons...] = interpolated_field
+    end
 
     # Add file to list of files that might need manual sync
     push!(writer.unsynced_datasets, nc)
@@ -703,14 +785,77 @@ end
         writer::NetCDFWriter,
         interpolated_field,
         diagnostic,
+        varname,
+        long_name,
+        units,
         dim_names,
         start_date,
     )
 
-Return the `var`iable stored in `nc` and the current temporal size, or if the
-`var`iable does not exist, then initialize and store the variable in `nc` with
-attributes about the `var`iable, and return the new NetCDF variable and 0 as the
-temporal size.
+Return the variable named `varname` stored in `nc` and the current temporal
+size, or if the variable does not exist, then initialize and store it in `nc`
+with `long_name`/`units` (and the other variable attributes), returning the new
+NetCDF variable and 0 as the temporal size.
+
+`varname`/`long_name`/`units` are passed in (rather than read off
+`diagnostic.variable`) because a `NamedTuple`-valued diagnostic produces one
+NetCDF variable per component, each with its own name, long name, and units.
+"""
+function get_var_and_t_index!(
+    nc,
+    FT,
+    writer::NetCDFWriter,
+    interpolated_field,
+    diagnostic,
+    varname,
+    long_name,
+    units,
+    dim_names,
+    start_date,
+)
+    var = diagnostic.variable
+    if haskey(nc, "$(varname)")
+        # We already have something in the file
+        v = nc["$(varname)"]
+        temporal_size, spatial_size... = size(v)
+        interpolated_size = size(interpolated_field)
+        spatial_size == interpolated_size ||
+            error("incompatible dimensions for $(varname)")
+    else
+        v = NCDatasets.defVar(
+            nc,
+            "$(varname)",
+            FT,
+            ("time", dim_names...),
+            deflatelevel = writer.compression_level,
+        )
+        v.attrib["short_name"] = varname::String
+        v.attrib["long_name"] = long_name::String
+        v.attrib["units"] = units::String
+        v.attrib["comments"] = var.comments::String
+        if !isnothing(start_date) && !haskey(v.attrib, "start_date")
+            v.attrib["start_date"] = string(start_date)::String
+        end
+        temporal_size = 0
+    end
+    return (v, temporal_size)
+end
+
+"""
+    get_var_and_t_index!(
+        nc,
+        FT,
+        writer::NetCDFWriter,
+        interpolated_field,
+        diagnostic,
+        dim_names,
+        start_date,
+    )
+
+Backwards-compatible method that derives the variable name, long name, and
+units from `diagnostic` (`short_name`, [`output_long_name`](@ref), and `units`
+respectively). This is the scalar/single-variable behavior; the
+`NamedTuple`-aware fan-out uses the explicit-name method above.
 """
 function get_var_and_t_index!(
     nc,
@@ -722,31 +867,18 @@ function get_var_and_t_index!(
     start_date,
 )
     var = diagnostic.variable
-    if haskey(nc, "$(var.short_name)")
-        # We already have something in the file
-        v = nc["$(var.short_name)"]
-        temporal_size, spatial_size... = size(v)
-        interpolated_size = size(interpolated_field)
-        spatial_size == interpolated_size ||
-            error("incompatible dimensions for $(var.short_name)")
-    else
-        v = NCDatasets.defVar(
-            nc,
-            "$(var.short_name)",
-            FT,
-            ("time", dim_names...),
-            deflatelevel = writer.compression_level,
-        )
-        v.attrib["short_name"] = var.short_name::String
-        v.attrib["long_name"] = output_long_name(diagnostic)::String
-        v.attrib["units"] = var.units::String
-        v.attrib["comments"] = var.comments::String
-        if !isnothing(start_date) && !haskey(v.attrib, "start_date")
-            v.attrib["start_date"] = string(start_date)::String
-        end
-        temporal_size = 0
-    end
-    return (v, temporal_size)
+    return get_var_and_t_index!(
+        nc,
+        FT,
+        writer,
+        interpolated_field,
+        diagnostic,
+        var.short_name,
+        output_long_name(diagnostic),
+        string(var.units),
+        dim_names,
+        start_date,
+    )
 end
 
 """

--- a/test/diagnostic_variable.jl
+++ b/test/diagnostic_variable.jl
@@ -1,4 +1,5 @@
 using Test
+import Logging
 import ClimaDiagnostics.DiagnosticVariables
 
 @testset "DiagnosticVariable" begin
@@ -30,4 +31,126 @@ import ClimaDiagnostics.DiagnosticVariables
 
     # Passing no compute or compute!
     @test_throws ErrorException DiagnosticVariables.DiagnosticVariable(;)
+end
+
+@testset "component_units" begin
+    cu = DiagnosticVariables.component_units
+
+    # String: shared across every component (and the scalar/empty chain)
+    @test cu("m/s", ()) == "m/s"
+    @test cu("m/s", (:a,)) == "m/s"
+
+    # NamedTuple: resolved per key (flat)
+    @test cu((; a = "m", b = "kg"), (:a,)) == "m"
+    @test cu((; a = "m", b = "kg"), (:b,)) == "kg"
+
+    # NamedTuple: descended along a nested property chain
+    @test cu((; warm = (; au = "1/s", ac = "1/s")), (:warm, :au)) == "1/s"
+
+    # NamedTuple: flat-leaf fallback for a nested chain
+    @test cu((; au = "1/s"), (:warm, :au)) == "1/s"
+
+    # Function: called with the property chain
+    @test cu(c -> join(string.(c), "."), (:warm, :au)) == "warm.au"
+
+    # No entry returns `nothing`; an explicit "" is a deliberate empty value
+    @test cu((; a = "m"), (:zzz,)) === nothing
+    @test cu((; a = ""), (:a,)) == ""
+    @test cu((; warm = (; au = "")), (:warm, :au)) == ""
+
+    # An `Int` chain element (Tuple/NTuple-element index) must NOT positional-
+    # index the units `NamedTuple` (regression: `haskey((; a=1), 1) == true`).
+    @test cu((; a = "m", b = "kg"), (1,)) === nothing
+    @test cu((; warm = (; au = "1/s")), (:warm, 1)) === nothing
+    # ...but the flat-leaf fallback still resolves a `Symbol` leaf past an `Int`
+    @test cu((; au = "1/s"), (2, :au)) == "1/s"
+end
+
+@testset "units_attribute" begin
+    ua = DiagnosticVariables.units_attribute
+
+    # String: returned unchanged, regardless of the property chains
+    @test ua("kg/m3", [()]) == "kg/m3"
+    @test ua("kg/m3", [(:a,), (:b,)]) == "kg/m3"
+
+    # NamedTuple (flat): one "chain: units" entry per component
+    @test ua((; cond = "x", evap = "y"), [(:cond,), (:evap,)]) ==
+          "cond: x, evap: y"
+
+    # NamedTuple (nested): chains are flattened with `.`
+    @test ua(
+        (; warm = (; au = "a", ac = "b"), tot = "c"),
+        [(:warm, :au), (:warm, :ac), (:tot,)],
+    ) == "warm.au: a, warm.ac: b, tot: c"
+
+    # NamedTuple: flat-leaf fallback is honoured (unlike `string(nt)`)
+    @test ua((; au = "1/s"), [(:warm, :au)]) == "warm.au: 1/s"
+
+    # Function: resolved per component
+    @test ua(chain -> "1/s", [(:warm, :au), (:tot,)]) ==
+          "warm.au: 1/s, tot: 1/s"
+
+    # A component with no matching entry gets an empty units value
+    @test ua((; cond = "x"), [(:cond,), (:evap,)]) == "cond: x, evap: "
+
+    # `Int` chain entries (Tuple-element indices) resolve to an empty value
+    # rather than positional-indexing the units `NamedTuple`.
+    @test ua((; a = "m"), [(1,), (:a,)]) == "1: , a: m"
+end
+
+@testset "units_warnings" begin
+    uw = DiagnosticVariables.units_warnings
+
+    # `String` is never checked (shared; the default `units` is `""`)
+    @test_logs min_level = Logging.Warn uw("kg/m3", [(:a,), (:b,)])
+    @test_logs min_level = Logging.Warn uw("", [(:a,), (:b,)])
+
+    # `Function`: a non-`nothing` return (incl. "") is explicit -> no logs
+    @test_logs min_level = Logging.Warn uw(c -> "1/s", [(:a,), (:b,)])
+    @test_logs min_level = Logging.Warn uw(
+        c -> c == (:b,) ? "" : "u",
+        [(:a,), (:b,)],
+    )
+    # `Function` returning `nothing` for a component: one warning
+    @test_logs (:warn,) uw(c -> c == (:b,) ? nothing : "u", [(:a,), (:b,)])
+
+    # Fully specified NamedTuple: no logs
+    @test_logs min_level = Logging.Warn uw((; a = "x", b = "y"), [(:a,), (:b,)])
+
+    # An entry explicitly set to "" is deliberate: no logs
+    @test_logs min_level = Logging.Warn uw((; a = ""), [(:a,)])
+    @test_logs min_level = Logging.Warn uw(
+        (; warm = (; au = "")),
+        [(:warm, :au)],
+    )
+
+    # A component with no matching key: one warning (a units entry that does
+    # not correspond to any component is NOT warned about)
+    @test_logs (:warn,) uw((; a = "m"), [(:b,)])
+
+    # Flat-leaf fallback resolves `:au`; only `:tot` has no entry: one warning
+    @test_logs (:warn,) uw((; au = "1/s"), [(:warm, :au), (:tot,)])
+
+    # `Int` chain entries (Tuple-element indices) cannot match a `NamedTuple`
+    # entry and resolve to no units: one warning.
+    @test_logs (:warn,) uw((; a = "m"), [(1,), (:a,)])
+end
+
+@testset "DiagnosticVariable non-string units" begin
+    # `units` may be a NamedTuple (per-component) ...
+    v_nt = DiagnosticVariables.DiagnosticVariable(;
+        compute = (u, p, t) -> 1,
+        short_name = "x",
+        units = (; a = "m", b = "s"),
+    )
+    @test v_nt.units == (; a = "m", b = "s")
+
+    # ... or a function of the property chain
+    units_fn = chain -> "u"
+    v_fn = DiagnosticVariables.DiagnosticVariable(;
+        compute = (u, p, t) -> 1,
+        short_name = "x",
+        units = units_fn,
+    )
+    @test v_fn.units === units_fn
 end

--- a/test/diagnostics.jl
+++ b/test/diagnostics.jl
@@ -184,3 +184,62 @@ include("TestTools.jl")
     @test length(handler_dup.scheduled_diagnostics) == 2
 
 end
+
+@testset "Diagnostics: NamedTuple-valued reduction" begin
+    # Regression for the per-leaf reduction path: a NamedTuple-eltype
+    # diagnostic with `reduction_time_func = +` driven through the real
+    # handler (the `writers.jl` tests call `write_field!` directly and
+    # skip this path).
+    t0 = 0.0
+    tf = 1.0
+    dt = 0.1
+    space = ColumnCenterFiniteDifferenceSpace()
+    Y = ClimaCore.Fields.FieldVector(; my_var = ones(space))
+    p = (; tau = -0.1)
+
+    exp_tendency!(dY, Y, p, _) = @. dY.my_var = p.tau * Y.my_var
+
+    # Returns a Field whose pointwise eltype is `NamedTuple{(:a, :b)}` with
+    # per-leaf values `(a = t, b = 2t)`.
+    function compute_nt(u, _, t)
+        z = ClimaCore.Fields.coordinate_field(axes(u.my_var)).z
+        return map(_ -> (; a = float(t), b = 2 * float(t)), z)
+    end
+
+    nt_var = ClimaDiagnostics.DiagnosticVariable(;
+        compute = compute_nt,
+        short_name = "nt",
+        long_name = "named tuple",
+        units = (; a = "u", b = "u"),
+    )
+
+    dict_writer = Writers.DictWriter()
+    nt_diag = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = nt_var,
+        output_writer = dict_writer,
+        reduction_time_func = +,
+        output_schedule_func = Schedules.DivisorSchedule(5),
+    )
+    short_name = ScheduledDiagnostics.output_short_name(nt_diag)
+
+    handler = ClimaDiagnostics.DiagnosticsHandler([nt_diag], Y, p, t0; dt)
+    diag_cb = ClimaDiagnostics.DiagnosticsCallback(handler)
+
+    prob = ClimaTimeSteppers.ODEProblem(
+        ClimaTimeSteppers.ClimaODEFunction(T_exp! = exp_tendency!),
+        Y,
+        (t0, tf),
+        p,
+    )
+    algo = ClimaTimeSteppers.ExplicitAlgorithm(ClimaTimeSteppers.RK4())
+    ClimaTimeSteppers.solve(prob, algo, dt = dt, callback = diag_cb)
+
+    # `DictWriter` keeps the NamedTuple-eltype field whole.
+    out = dict_writer[short_name][0.5]
+    @test eltype(out) <: NamedTuple
+    # The `+` accumulator broadcasts per-leaf: at t = 0.5 it has summed
+    # 0.0, 0.1, ..., 0.5 in `a` and twice that in `b`.
+    expected_a = sum(t0:dt:0.5)
+    @test all(parent(out.a) .≈ expected_a)
+    @test all(parent(out.b) .≈ 2 * expected_a)
+end

--- a/test/writers.jl
+++ b/test/writers.jl
@@ -1658,3 +1658,231 @@ end
         end
     end
 end
+
+@testset "NamedTuple diagnostics" begin
+    space = SphericalShellSpace()
+    NUM = 10
+    z = Fields.coordinate_field(space).z
+
+    p = (; start_date = Dates.DateTime(2010, 1, 1))
+    t = 10.0
+
+    # `field` is passed directly to interpolate_field!/write_field! below
+    # (matching the pattern used throughout this file), so this is never called.
+    nt_compute!(out, u, p, t) = nothing
+
+    # --- Flat NamedTuple: one variable per key, units via a NamedTuple ---
+    flat_field = map(zz -> (; cond = zz, evap = 2 * zz, acc = 3 * zz), z)
+    flat_writer = Writers.NetCDFWriter(
+        space,
+        output_dir;
+        num_points = (NUM, 2NUM, 3NUM),
+        start_date = Dates.DateTime(2010, 1, 1),
+    )
+    flat_diag = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "clw_tend",
+            long_name = "cloud tendency",
+            units = (; cond = "kg/kg/s", evap = "kg/kg/s", acc = "1/s"),
+        ),
+        output_short_name = "nt_flat",
+        output_long_name = "cloud tendency",
+        output_writer = flat_writer,
+    )
+    Writers.interpolate_field!(flat_writer, flat_field, flat_diag, (;), p, t)
+    Writers.write_field!(flat_writer, flat_field, flat_diag, (;), p, t)
+    # Write a second time: regression for the shared-time-index bug (all
+    # components must land at the same time index, and time/date bounds for
+    # every index must be written, i.e. no fill values).
+    Writers.write_field!(flat_writer, flat_field, flat_diag, (;), p, t)
+    close(flat_writer)
+
+    NCDatasets.NCDataset(joinpath(output_dir, "nt_flat.nc")) do nc
+        comps = sort([k for k in keys(nc) if startswith(k, "clw_tend")])
+        @test comps == ["clw_tend_acc", "clw_tend_cond", "clw_tend_evap"]
+        @test nc["clw_tend_cond"].attrib["units"] == "kg/kg/s"
+        @test nc["clw_tend_acc"].attrib["units"] == "1/s"
+        @test nc["clw_tend_cond"].attrib["short_name"] == "clw_tend_cond"
+        @test occursin("cond", nc["clw_tend_cond"].attrib["long_name"])
+        # 2 writes (time), horizontal dims; vertical uses the space levels
+        @test size(nc["clw_tend_cond"])[1:3] == (2, NUM, 2NUM)
+        @test nc["time"][:] == [10.0, 10.0]
+        @test !any(>(1e30), Array(nc["date_bnds"].var))
+        # The flat field is z -> (cond=z, evap=2z, acc=3z); the per-component
+        # scaling must be preserved after the (independent) interpolations.
+        cond_arr = Array(nc["clw_tend_cond"])
+        evap_arr = Array(nc["clw_tend_evap"])
+        acc_arr = Array(nc["clw_tend_acc"])
+        @test evap_arr ≈ 2 .* cond_arr
+        @test acc_arr ≈ 3 .* cond_arr
+    end
+
+    # --- Nested NamedTuple: recursive flatten, units via a function ---
+    nested_field =
+        map(zz -> (; warm = (; au = zz, ac = 2 * zz), tot = 9 * zz), z)
+    nested_writer = Writers.NetCDFWriter(
+        space,
+        output_dir;
+        num_points = (NUM, 2NUM, 3NUM),
+        start_date = Dates.DateTime(2010, 1, 1),
+    )
+    nested_diag = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "proc",
+            long_name = "processes",
+            units = chain -> "1/s",
+        ),
+        output_short_name = "nt_nested",
+        output_long_name = "processes",
+        output_writer = nested_writer,
+    )
+    Writers.interpolate_field!(
+        nested_writer,
+        nested_field,
+        nested_diag,
+        (;),
+        p,
+        t,
+    )
+    Writers.write_field!(nested_writer, nested_field, nested_diag, (;), p, t)
+    close(nested_writer)
+    NCDatasets.NCDataset(joinpath(output_dir, "nt_nested.nc")) do nc
+        comps = sort([k for k in keys(nc) if startswith(k, "proc")])
+        @test comps == ["proc_tot", "proc_warm_ac", "proc_warm_au"]
+        @test nc["proc_warm_au"].attrib["units"] == "1/s"
+        @test size(nc["proc_tot"])[1:3] == (1, NUM, 2NUM)
+    end
+
+    # --- Scalar diagnostic is unchanged (regression) ---
+    scalar_writer = Writers.NetCDFWriter(
+        space,
+        output_dir;
+        num_points = (NUM, 2NUM, 3NUM),
+        start_date = Dates.DateTime(2010, 1, 1),
+    )
+    scalar_diag = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "rho",
+            long_name = "density",
+            units = "kg/m3",
+        ),
+        output_short_name = "nt_scalar",
+        output_long_name = "density",
+        output_writer = scalar_writer,
+    )
+    Writers.interpolate_field!(scalar_writer, z, scalar_diag, (;), p, t)
+    Writers.write_field!(scalar_writer, z, scalar_diag, (;), p, t)
+    close(scalar_writer)
+    NCDatasets.NCDataset(joinpath(output_dir, "nt_scalar.nc")) do nc
+        @test haskey(nc, "rho")  # bare short name, no component suffix
+        @test nc["rho"].attrib["units"] == "kg/m3"
+        @test nc["rho"].attrib["short_name"] == "rho"
+        @test nc["rho"].attrib["long_name"] == "density"
+    end
+
+    # --- PointSpace fan-out via set_pointspace_output! ---
+    point_space = Spaces.PointSpace(ClimaComms.context(), Geometry.ZPoint(1.0))
+    point_nt = map(
+        _z -> (; cond = 1.0, evap = 2.0),
+        Fields.coordinate_field(point_space).z,
+    )
+    point_writer = Writers.NetCDFWriter(point_space, output_dir)
+    point_diag = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "pnt",
+            long_name = "point nt",
+            units = (; cond = "a", evap = "b"),
+        ),
+        output_short_name = "nt_point",
+        output_long_name = "point nt",
+        output_writer = point_writer,
+    )
+    Writers.set_pointspace_output!(point_writer, point_diag, point_nt)
+    Writers.write_field!(point_writer, point_nt, point_diag, (;), p, t)
+    Writers.set_pointspace_output!(point_writer, point_diag, point_nt)
+    Writers.write_field!(point_writer, point_nt, point_diag, (;), p, t)
+    close(point_writer)
+    NCDatasets.NCDataset(joinpath(output_dir, "nt_point.nc")) do nc
+        @test nc["pnt_cond"][:] == [1.0, 1.0]
+        @test nc["pnt_evap"][:] == [2.0, 2.0]
+        @test nc["pnt_cond"].attrib["units"] == "a"
+        @test nc["pnt_evap"].attrib["units"] == "b"
+    end
+
+    # --- HDF5Writer + DictWriter take NamedTuple fields unsplit ---
+    # (HDF5 also exercises the non-String `units` attribute path)
+    h5_writer = Writers.HDF5Writer(output_dir)
+    h5_diag = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "h5nt",
+            units = chain -> "1/s",
+        ),
+        output_short_name = "nt_h5",
+        output_long_name = "nt h5",
+        output_writer = h5_writer,
+    )
+    Writers.write_field!(h5_writer, nested_field, h5_diag, (;), p, 0.0)
+    @test isfile(joinpath(output_dir, "nt_h5_0.0.h5"))
+    # The whole NamedTuple field is stored as one dataset, so per-component
+    # `units` (here a function of the property chain) are resolved for every
+    # leaf and flattened into the single `variable_units` attribute.
+    h5 = ClimaCore.InputOutput.HDF5
+    h5_units = h5.h5open(joinpath(output_dir, "nt_h5_0.0.h5"), "r") do f
+        h5.read_attribute(f, "variable_units")
+    end
+    @test h5_units == "warm.au: 1/s, warm.ac: 1/s, tot: 1/s"
+
+    # Same, but with per-component units given as a NamedTuple
+    h5_writer_nt = Writers.HDF5Writer(output_dir)
+    h5_diag_nt = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "h5ntnt",
+            units = (; warm = (; au = "a", ac = "b"), tot = "c"),
+        ),
+        output_short_name = "nt_h5_nt",
+        output_long_name = "nt h5 nt",
+        output_writer = h5_writer_nt,
+    )
+    Writers.write_field!(h5_writer_nt, nested_field, h5_diag_nt, (;), p, 0.0)
+    h5_units_nt = h5.h5open(joinpath(output_dir, "nt_h5_nt_0.0.h5"), "r") do f
+        h5.read_attribute(f, "variable_units")
+    end
+    @test h5_units_nt == "warm.au: a, warm.ac: b, tot: c"
+
+    # A plain String `units` is written unchanged (unchanged behavior)
+    h5_writer_s = Writers.HDF5Writer(output_dir)
+    h5_diag_s = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "h5s",
+            units = "kg/m3",
+        ),
+        output_short_name = "nt_h5_s",
+        output_long_name = "nt h5 s",
+        output_writer = h5_writer_s,
+    )
+    Writers.write_field!(h5_writer_s, nested_field, h5_diag_s, (;), p, 0.0)
+    h5_units_s = h5.h5open(joinpath(output_dir, "nt_h5_s_0.0.h5"), "r") do f
+        h5.read_attribute(f, "variable_units")
+    end
+    @test h5_units_s == "kg/m3"
+
+    dict_writer = Writers.DictWriter()
+    dict_diag = ClimaDiagnostics.ScheduledDiagnostic(;
+        variable = ClimaDiagnostics.DiagnosticVariable(;
+            compute! = nt_compute!,
+            short_name = "dnt",
+        ),
+        output_short_name = "nt_dict",
+        output_long_name = "nt dict",
+        output_writer = dict_writer,
+    )
+    Writers.write_field!(dict_writer, nested_field, dict_diag, (;), p, 0.0)
+    @test eltype(dict_writer["nt_dict"][0.0]) <: NamedTuple
+end


### PR DESCRIPTION
## Purpose

Lets a compute function that returns a `Field` of `NamedTuple`s be registered as a single `DiagnosticVariable` and fan out into one scalar NetCDF variable per component, automatically. Motivated by an upcoming CloudMicrophysics debug mode in ClimaAtmos, which produces per-process tendencies as a `NamedTuple` at every grid point — previously this required N hand-written `compute` callbacks (one per process) and N `DiagnosticVariable` registrations to surface in NetCDF.

## Example

A `compute` returning a `Field{@NamedTuple{cond, evap, accr}}`:

```julia
compute_micro(state, cache, time) = cache.microphysics_tendencies

DiagnosticVariable(;
    short_name = "clw_tend",     # stem, not the variable name
    long_name  = "cloud liquid water tendency",
    units      = "kg kg⁻¹ s⁻¹",  # or per-component:
                                  # (; cond = ..., evap = ..., accr = ...)
    compute    = compute_micro,
)
```

yields three NetCDF variables in a single file — `clw_tend_cond`, `clw_tend_evap`, `clw_tend_accr` (with `long_name` `"cloud liquid water tendency (cond)"`, etc.). Nested `NamedTuple`s flatten recursively: `@NamedTuple{warm::@NamedTuple{au, ac}, tot}` with `short_name = "proc"` gives `proc_warm_au`, `proc_warm_ac`, `proc_tot`.

Scalar diagnostics, reductions (incl. time averaging), and the `HDF5Writer` / `DictWriter` paths are unchanged. See the new [NamedTuple diagnostics](docs/src/namedtuple_diagnostics.md) docs page for the full API.

## Content

- Per-component fan-out at the `NetCDFWriter` boundary (scalar remapper reused, one shared `time` index per write)
- Per-component `units` accepting `String | NamedTuple | Function`
- New docs page + NEWS entry, bump to v0.3.6
- Tests: NetCDF fan-out (flat / nested / scalar), per-component units, PointSpace, HDF5/Dict pass-through, end-to-end NamedTuple `+` reduction through `DiagnosticsHandler`, units resolvers

----
- [x] I have read and checked the items on the review checklist.
